### PR TITLE
스토리북의 CI/CD를 구현한다

### DIFF
--- a/.github/workflows/push-another-repo.yml
+++ b/.github/workflows/push-another-repo.yml
@@ -1,0 +1,34 @@
+# Vercel cannot support organization repo deploy in hobby account.
+# So I make workflow to push another repo to deploy to Vercel
+
+name: Deploy
+
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install pnpm
+        run: npm i pnpm@latest -g
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Check build for deploy in stable 
+        run: pnpm build
+
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: '.'
+          destination-github-username: 'JengYoung'
+          destination-repository-name: 'seeyouletter-fe'
+          user-email: young_pallete@naver.com
+          target-branch: main

--- a/.github/workflows/push-another-repo.yml
+++ b/.github/workflows/push-another-repo.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
 jobs:
   test:


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->

`Storybook` 배포 과정을 테스트하려 한다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

closes #8 

## 💡 논의해볼 사항

### Vercel not support deployment organization repo when using hobby plan account

Vercel에서 배포를 하려 했는데, 레포지토리를 찾을 수 없다.
따라서 이를 https://github.com/orgs/vercel/discussions/123 에 검색해보니, 결과적으로 `Vercel` 팀은 팀 플랜일 경우에 지원한다고 한다.
따라서 이를 우회하는 방법을 택해야 했다.

1. 메인에 푸시
2. 메인에 버전 태그는 여기서 + 소스코드를 다른 레포지토리(개인 repo)에 푸시
3. 개인 repo가 변경되면 Vercel에서 배포할 수 있도록 설정
4. 배포

이것이 가능할 것 같기는 하다. 좋다고 할 수는 없겠지만.
따라서 일단 시도해본다!

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

https://github.com/orgs/vercel/discussions/123

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!