### PR TITLE
Select 컴포넌트를 추가한다

### DIFF
--- a/.changeset/four-tigers-call.md
+++ b/.changeset/four-tigers-call.md
@@ -1,0 +1,5 @@
+---
+'tsconfig': patch
+---
+
+DOM 옵션을 추가하여, e.target.value 등을 찾을 수 있도록 지원한다.

--- a/apps/storybook-ui/.storybook/preview.tsx
+++ b/apps/storybook-ui/.storybook/preview.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import {ThemeProvider} from '@emotion/react';
-import { CustomThemeProvider, globalTheme } from 'ui';
+import { CustomThemeProvider } from 'ui';
 
 import { viewports, MINIMAL_VIEWPORTS, DEFAULT_VIEWPORT } from './viewPortsMap';
 

--- a/apps/storybook-ui/src/stories/Select/Select.stories.mdx
+++ b/apps/storybook-ui/src/stories/Select/Select.stories.mdx
@@ -34,6 +34,52 @@ import { DefaultSelect } from 'ui';
   title="Components/Select"
   component={DefaultSelect}
   argTypes={{
+    width: {
+      name: 'width',
+      description: '너비를 지정해줍니다.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: '84px',
+        },
+      },
+    },
+    height: {
+      name: 'height',
+      description: '높이를 지정해줍니다.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: '32px',
+        },
+      },
+    },
+    size: {
+      name: 'size',
+      description: '폰트 사이즈를 지정할 수 있어요.',
+      control: {
+        type: 'radio',
+        options: ['lg', 'md', 'sm', 'xs'],
+      },
+      table: {
+        type: {
+          summary: ['lg', 'md', 'sm', 'xs'],
+        },
+        defaultValue: {
+          summary: 'md',
+        },
+      },
+    },
     options: {
       name: 'options',
       description:
@@ -117,6 +163,8 @@ export const SelectTemplate = (args) => <DefaultSelect {...args} />;
   <Story
     name="설명"
     args={{
+      width: '84px',
+      height: '32px',
       options: [
         {
           label: '셀렉트 옵션 1입니다.',
@@ -160,6 +208,9 @@ export const SelectTemplate = (args) => <DefaultSelect {...args} />;
   <Story
     name="props | placeholder"
     args={{
+      width: '84px',
+      height: '32px',
+      size: 'sm',
       options: [
         {
           label: '셀렉트 옵션 1입니다.',
@@ -202,6 +253,9 @@ export const SelectTemplate = (args) => <DefaultSelect {...args} />;
     style="display: block;"
     name="props | activeOption"
     args={{
+      width: '84px',
+      height: '32px',
+      size: 'sm',
       options: [
         {
           label: '셀렉트 옵션 1입니다.',

--- a/apps/storybook-ui/src/stories/Select/Select.stories.mdx
+++ b/apps/storybook-ui/src/stories/Select/Select.stories.mdx
@@ -1,0 +1,233 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+import { DefaultSelect } from 'ui';
+
+<style>
+  {`
+  h2,
+  h6 {
+    font-weight: 700;
+    display: block;
+  }
+  code {
+    line-height: 1;
+    margin: 0 2px;
+    padding: 3px 5px;
+    white-space: nowrap;
+    border-radius: 3px;
+    font-size: 13px;
+    border: 1px solid #EEEEEE;
+    color: rgba(51,51,51,0.9);
+    background-color: #F8F8F8;
+  }
+`}
+</style>
+
+# Select
+
+옵션을 받아서 사용할 수 있는, 선택할 수 있는 컴포넌트입니다.  
+웹 표준 시멘틱 태그로 지원하기 때문에 모바일에서 사용할 때에도 UI/UX가 표준으로 유지될 수 있어요! 🙆🏻🙆🏻‍♀️
+
+> 추후 여유 시간이 존재한다면 직접 구현하거나 써드파티 라이브러리를 도입할 예정입니다.
+
+<Meta
+  title="Components/Select"
+  component={DefaultSelect}
+  argTypes={{
+    options: {
+      name: 'options',
+      description:
+        '옵션을 지정해줄 수 있어요. label과 실제 들어갈 value를 별도로 구분해줄 수 있어요.',
+      control: {
+        type: 'array',
+      },
+      table: {
+        type: {
+          summary: 'OptionInterface[]',
+          detail: `
+interface OptionInterface {
+  label: string;
+  value: string;
+}
+          `,
+        },
+        defaultValue: {
+          summary: '[]',
+        },
+      },
+    },
+    placeholder: {
+      name: 'placeholder 🚨',
+      description:
+        '옵션이 선택되지 않은 것을 원할 수 있어요. 그럴 때에는 placeholder을 통해 선택을 요청할 수 있어요. <br/> 만약 이 값이 없다면, 옵션의 맨 첫 번째 것이 defaultValue로 선택되어 있어요!',
+      control: {
+        type: 'text',
+      },
+      table: {
+        type: {
+          summary: 'string',
+          detail: '만약 이 값이 없다면, 옵션의 맨 첫 번째 것이 defaultValue로 선택되어 있어요!',
+        },
+        defaultValue: {
+          summary: '',
+        },
+      },
+    },
+    activeOption: {
+      name: 'activeOption',
+      description: 'optional한 값이며, 초기에 어떤 옵션을 선택되게 할 것인지 지정 가능해요.',
+      control: {
+        type: 'object',
+      },
+      table: {
+        type: {
+          summary: 'undefined | OptionInterface',
+          detail: `
+interface OptionInterface {
+  label: string;
+  value: string;
+}
+          `,
+        },
+        defaultValue: {
+          summary: undefined,
+        },
+      },
+    },
+    onChange: {
+      action: 'changed',
+      table: {
+        type: {
+          summary: '(option: OptionInterface) => void',
+          detail: `
+interface OptionInterface {
+  label: string;
+  value: string;
+}          
+          `,
+        },
+      },
+    },
+  }}
+/>
+
+export const SelectTemplate = (args) => <DefaultSelect {...args} />;
+
+<Canvas>
+  <Story
+    name="설명"
+    args={{
+      options: [
+        {
+          label: '셀렉트 옵션 1입니다.',
+          value: 'option 1',
+        },
+        {
+          label: '셀렉트 옵션 2입니다.',
+          value: 'option 2',
+        },
+        {
+          label: '셀렉트 옵션 3입니다.',
+          value: 'option 3',
+        },
+      ],
+      placeholder: '',
+      activeOption: undefined,
+    }}
+  >
+    {SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="설명" />
+
+<br />
+<br />
+<br />
+
+# props
+
+<br />
+
+## placeholder
+
+씨유레터는 초기에 값을 지정해주지 않을 수 있어요.  
+대신 선택을 유도할 수 있도록 `placeholder`을 지원해주기로 했습니다.
+
+> 이는 단지 선택 사항이며, UX를 고려해서 사용을 선택해주세요!
+
+<Canvas>
+  <Story
+    name="props | placeholder"
+    args={{
+      options: [
+        {
+          label: '셀렉트 옵션 1입니다.',
+          value: 'option 1',
+        },
+        {
+          label: '셀렉트 옵션 2입니다.',
+          value: 'option 2',
+        },
+        {
+          label: '셀렉트 옵션 3입니다.',
+          value: 'option 3',
+        },
+      ],
+      placeholder: '옵션을 선택해주세요 🙆🏻',
+      activeOption: undefined,
+    }}
+  >
+    {SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="props | placeholder" />
+
+<br />
+<br />
+<br />
+
+## activeOption
+
+씨유레터의 셀렉트는 `activeOption`을 추가로 지원해요.  
+만약 초기에 로컬스토리지나 서버에서 사용자가 설정했던 옵션이 초기화되면, 기분이 좋지 않겠죠?  
+따라서 이를 충분히 지원할 수 있도록, activeOption을 지정해줄 수 있어요 🙆🏻🙆🏻‍♀️
+
+> 주의사항: 반드시 `options` 안에 포함되어 있어야 해요.  
+> 또한, `value`에는 JSON의 직렬화를 이용한 간단한 비교만 수행되어 옵션이 활성화 되므로, 이를 주의합니다.
+
+<Canvas>
+  <Story
+    style="display: block;"
+    name="props | activeOption"
+    args={{
+      options: [
+        {
+          label: '셀렉트 옵션 1입니다.',
+          value: 'option 1',
+        },
+        {
+          label: '셀렉트 옵션 2입니다.',
+          value: 'option 2',
+        },
+        {
+          label: '셀렉트 옵션 3입니다.',
+          value: 'option 3',
+        },
+      ],
+      placeholder: '카테고리를 선택해주세요.',
+      activeOption: {
+        label: '셀렉트 옵션 2입니다.',
+        value: 'option 2',
+      },
+    }}
+  >
+    {SelectTemplate.bind({})}
+  </Story>
+  <h4>
+    <code>placeholder</code>가 있어도 걱정 마세요. <code>activeOption</code>이 우선합니다.
+  </h4>
+</Canvas>
+
+<ArgsTable story="props | activeOption" />

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -4,7 +4,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["ES2015"],
+    "lib": ["ES2015", "DOM"],
     "module": "ESNext",
     "target": "ESNext"
   }

--- a/packages/ui/Select/Default.tsx
+++ b/packages/ui/Select/Default.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Mobile } from './Mobile';
+import { SelectPropsInterface } from './types';
+
+/**
+ *
+ * @param {options, placeholder}
+ * @returns Select.Mobile (현재는 Mobile에 관한 Select만 우선적으로 구현합니다.)
+ */
+export const Default = ({ options, placeholder }: SelectPropsInterface) => {
+  return <Mobile options={options} placeholder={placeholder}></Mobile>;
+};

--- a/packages/ui/Select/Default.tsx
+++ b/packages/ui/Select/Default.tsx
@@ -8,6 +8,18 @@ import { SelectPropsInterface } from './types';
  * @param {options, placeholder}
  * @returns Select.Mobile (현재는 Mobile에 관한 Select만 우선적으로 구현합니다.)
  */
-export const Default = ({ options, placeholder }: SelectPropsInterface) => {
-  return <Mobile options={options} placeholder={placeholder}></Mobile>;
+export const DefaultSelect = ({
+  options = [],
+  placeholder,
+  onChange,
+  activeOption,
+}: SelectPropsInterface) => {
+  return (
+    <Mobile
+      options={options}
+      placeholder={placeholder}
+      onChange={onChange}
+      activeOption={activeOption}
+    ></Mobile>
+  );
 };

--- a/packages/ui/Select/Default.tsx
+++ b/packages/ui/Select/Default.tsx
@@ -9,6 +9,9 @@ import { SelectPropsInterface } from './types';
  * @returns Select.Mobile (현재는 Mobile에 관한 Select만 우선적으로 구현합니다.)
  */
 export const DefaultSelect = ({
+  width = '84px',
+  height = '32px',
+  size = 'sm',
   options = [],
   placeholder,
   onChange,
@@ -16,6 +19,9 @@ export const DefaultSelect = ({
 }: SelectPropsInterface) => {
   return (
     <Mobile
+      width={width}
+      height={height}
+      size={size}
       options={options}
       placeholder={placeholder}
       onChange={onChange}

--- a/packages/ui/Select/Mobile.tsx
+++ b/packages/ui/Select/Mobile.tsx
@@ -20,7 +20,15 @@ import { SelectPropsInterface } from './types';
  * @see: 또다른 데스크톱에서 쓸만한 컴포넌트를 찾았습니다.
  * https://github.com/csandman/chakra-react-select
  */
-export const Mobile = ({ options, placeholder, onChange, activeOption }: SelectPropsInterface) => {
+export const Mobile = ({
+  width,
+  height,
+  size,
+  options,
+  placeholder,
+  onChange,
+  activeOption,
+}: SelectPropsInterface) => {
   const selectRef = useRef<HTMLSelectElement | null>(null);
   const selectedOption = useRef(placeholder ? null : options[0]);
 
@@ -56,6 +64,10 @@ export const Mobile = ({ options, placeholder, onChange, activeOption }: SelectP
 
   return (
     <Select
+      width={width}
+      height={height}
+      size={size}
+      borderRadius="10px"
       ref={selectRef}
       placeholder={placeholder}
       variant="outline"

--- a/packages/ui/Select/Mobile.tsx
+++ b/packages/ui/Select/Mobile.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { BaseSyntheticEvent, useEffect, useRef } from 'react';
 
 import { Select } from '@chakra-ui/react';
 
@@ -20,9 +20,52 @@ import { SelectPropsInterface } from './types';
  * @see: 또다른 데스크톱에서 쓸만한 컴포넌트를 찾았습니다.
  * https://github.com/csandman/chakra-react-select
  */
-export const Mobile = ({ options, placeholder }: SelectPropsInterface) => {
+export const Mobile = ({ options, placeholder, onChange, activeOption }: SelectPropsInterface) => {
+  const selectRef = useRef<HTMLSelectElement | null>(null);
+  const selectedOption = useRef(placeholder ? null : options[0]);
+
+  const handleSelect = (e: BaseSyntheticEvent) => {
+    const { selectedIndex } = e.target;
+
+    const nextSelectedOption = placeholder
+      ? options[selectedIndex - 1] ?? null
+      : options[selectedIndex];
+
+    selectedOption.current = nextSelectedOption;
+    onChange(selectedOption.current);
+  };
+
+  useEffect(() => {
+    if (!selectRef.current || !activeOption) return;
+
+    const selectedOptionIndex = options.findIndex(
+      (option) =>
+        JSON.stringify(activeOption.value) === JSON.stringify(option.value) &&
+        activeOption.label === option.label
+    );
+
+    if (selectedOptionIndex < 0) return;
+
+    const nextSelectedOptionIndex = selectedOptionIndex + +!!placeholder;
+
+    selectedOption.current = options[nextSelectedOptionIndex];
+    selectRef.current.selectedIndex = nextSelectedOptionIndex;
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, []);
+
   return (
-    <Select placeholder={placeholder} variant="outline" color="sub.500" borderColor="sub.500">
+    <Select
+      ref={selectRef}
+      placeholder={placeholder}
+      variant="outline"
+      color="primary.900"
+      borderColor="sub.500"
+      focusBorderColor="primary.500"
+      onChange={(e) => {
+        handleSelect(e);
+      }}
+    >
       {options.map((option) => (
         <option key={option.value} value={option.value}>
           {option.label}

--- a/packages/ui/Select/Mobile.tsx
+++ b/packages/ui/Select/Mobile.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { Select } from '@chakra-ui/react';
+
+import { SelectPropsInterface } from './types';
+
+/**
+ * @description
+ * 컴포넌트 이름이 Mobile인 이유는, `Select` 컴포넌트를 디바이스에 따라 분리하기 위함입니다.
+ * 이유: 모바일에서 select - option Tag는 상당한 UX 강점을 제공합니다.
+ * `chakra-ui`의 경우 이러한 시멘틱 태그를 따르므로 모바일에서는 강점이 분명 있습니다.
+ *
+ * 그러나 애석하게도 데스크탑에서는 이것이 오점으로 남습니다. 특히 크로스 브라우징에서의 아쉬움이 존재합니다.
+ * 일관성 있는 디자인 시스템 사이에서 파란색으로 option이 나오는 부분은 우스꽝스럽기도 합니다.
+ * 따라서 현재는 구현하기 쉬운 모바일 버전의 셀렉트를 구현하고, 추후 별개로 구현하려 합니다.
+ *
+ * @see: 다음은 Select-option의 스타일 지정이 까다로운 이유를 설명합니다.
+ * https://stackoverflow.com/questions/7208786/how-to-style-the-option-of-an-html-select-element
+ *
+ * @see: 또다른 데스크톱에서 쓸만한 컴포넌트를 찾았습니다.
+ * https://github.com/csandman/chakra-react-select
+ */
+export const Mobile = ({ options, placeholder }: SelectPropsInterface) => {
+  return (
+    <Select placeholder={placeholder} variant="outline" color="sub.500" borderColor="sub.500">
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </Select>
+  );
+};

--- a/packages/ui/Select/index.ts
+++ b/packages/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export * from './Default';
+export * from './Mobile';

--- a/packages/ui/Select/types.ts
+++ b/packages/ui/Select/types.ts
@@ -1,9 +1,14 @@
+import { SizeType } from 'common/types';
+
 export interface OptionInterface {
   label: string;
   value: string;
 }
 
 export interface SelectPropsInterface {
+  width?: string;
+  height?: string;
+  size?: SizeType;
   options: OptionInterface[];
   placeholder?: string;
   activeOption?: OptionInterface;

--- a/packages/ui/Select/types.ts
+++ b/packages/ui/Select/types.ts
@@ -4,6 +4,13 @@ export interface OptionInterface {
 }
 
 export interface SelectPropsInterface {
-  placeholder?: string;
   options: OptionInterface[];
+  placeholder?: string;
+  activeOption?: OptionInterface;
+  /**
+   *
+   * @param option
+   * @inner 만약 placeholder가 있다면 null이 나올 수 있습니다.
+   */
+  onChange: (option: OptionInterface | null) => void;
 }

--- a/packages/ui/Select/types.ts
+++ b/packages/ui/Select/types.ts
@@ -1,0 +1,9 @@
+export interface OptionInterface {
+  label: string;
+  value: string;
+}
+
+export interface SelectPropsInterface {
+  placeholder?: string;
+  options: OptionInterface[];
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -5,3 +5,4 @@ export * from './Icon';
 export * from './Input';
 export * from './Link';
 export * from './Tabs';
+export * from './Select';


### PR DESCRIPTION
## 💌 설명

다양한 옵션들 중 특정 옵션을 선택 가능한 `Select` 컴포넌트를 추가했다.
기존에 `chakra-ui`가 지원해주는 기능이 많이 빈약한 컴포넌트라, 내가 직접 몇 가지 옵션들을 추가했다.

## 📎 관련 이슈

closes #27 

## 💡 논의해볼 사항

### Cross Platform Issue

어떻게 보면 표준을 잘 따르고 있기는 하지만, 윈도우에서의 셀렉트 옵션은 굉장히 UI적으로 이쁘지 않다.
그렇지만, 이를 그대로 반영하고 있다는 게 좀 마음에 걸린다.

그렇지만 이를 포기하고 내가 직접 커스터마이징하여 만들기에는, 추후 모바일에서 이를 선택할 때 나오는 모달 형태의 셀렉트 창이 너무 아깝다.
분명 모바일에서는 드롭다운보다는 모달 형태가 더욱 설득력 있어보이기 때문이다.

따라서 추후 `Navigator.agent` 옵션을 활용하여 적응형으로 컴포넌트를 뿌려볼까 생각한다.

이는 상위 컴포넌트인 `Default`에서 제어하고, `Default`는 초기 디바이스 형태를 제어 받아 `Select`의 형태를 바꿔주는 것이다.
이것이 가능한 이유는, 디바이스 변경을 사용자가 갑자기 화면 상에서 조작할 수 없기 때문이다.

이는 좀 더 디벨롭하고자 이슈로 남겨놔야겠다!



## 📝 참고자료

괜찮은 `Chakra-ui` wrapper select library를 찾았다.
이를 나중에 참고한다.
[csandman/chakra-react-select](https://github.com/csandman/chakra-react-select)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
