### PR TITLE
TemplateModal을 구현한다

### DIFF
--- a/apps/docs/pages/index.tsx
+++ b/apps/docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { DefaultButton } from '@ui/index';
+import { DefaultButton } from 'ui';
 
 export default function Docs() {
   const [state, setState] = useState(false);

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@ui/*": ["../../packages/ui/*"]
+      "@ui/*": ["../../packages/ui/*"],
+      "@common-hooks/*": ["../../packages/common-hooks/*"]
     },
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react"

--- a/apps/web/atoms/toastAtom.ts
+++ b/apps/web/atoms/toastAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 
-import { ToastBoxInterface } from '@ui/toast/types';
+import { ToastBoxInterface } from 'ui';
 
 export interface toastAtomInterface extends ToastBoxInterface {
   toastId: string;

--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -16,8 +16,11 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@pages/(.*)$': '<rootDir>/pages/$1',
     '^@hooks/(.*)$': '<rootDir>/hooks/$1',
+    '^@utils/(.*)$': '<rootDir>/libs/utils/$1',
+    '^@apis/(.*)$': '<rootDir>/libs/apis/$1',
     '^@templates/(.*)$': '<rootDir>/templates/$1',
     '^@ui/(.*)$': '<rootDir>/../../packages/ui/$1',
+    '^@common-hooks/(.*)$': '<rootDir>/../../packages/common-hooks/$1',
   },
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],

--- a/apps/web/pages/config/phone-number/index.tsx
+++ b/apps/web/pages/config/phone-number/index.tsx
@@ -5,8 +5,15 @@ import styled from '@emotion/styled';
 
 import ConfigLayout from 'layouts/ConfigLayout';
 
-import { DefaultButtonPropsInterface } from '@ui/button/types';
-import { DefaultButton, DefaultHStack, FormInput, FullWidthButton, IconHeaderText, Logo } from 'ui';
+import {
+  DefaultButton,
+  DefaultButtonPropsInterface,
+  DefaultHStack,
+  FormInput,
+  FullWidthButton,
+  IconHeaderText,
+  Logo,
+} from 'ui';
 
 import { ConfigForm } from '@templates/index';
 

--- a/apps/web/pages/find/index.tsx
+++ b/apps/web/pages/find/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import BaseLayout from 'layouts/BaseLayout';
 
-import { DefaultSelect } from '@ui/select';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
-import { TabGroup } from '@ui/tabs';
+import { DefaultHStack, DefaultSelect, DefaultVStack, TabGroup } from 'ui';
 
 import { TemplateCardList } from '@templates/card-list';
 import { FindTemplateSearchForm } from '@templates/form';

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -4,9 +4,14 @@ import { v4 as uuidV4 } from 'uuid';
 
 import BaseLayout from 'layouts/BaseLayout';
 
-import { DefaultBanner } from '@ui/banner';
-import Carousel from '@ui/carousel/Carousel';
-import { DefaultButton, DefaultText, DefaultVStack, StrongText } from 'ui';
+import {
+  DefaultBanner,
+  DefaultButton,
+  DefaultCarousel,
+  DefaultText,
+  DefaultVStack,
+  StrongText,
+} from 'ui';
 
 import { TemplateCardList } from '@templates/index';
 
@@ -36,14 +41,13 @@ const CarouselData = [
     button: <DefaultButton>템플릿 만들기 💌</DefaultButton>,
   },
 ];
-
 export default function Web() {
   const theme = useTheme();
 
   return (
     <div>
       <DefaultVStack marginBottom={8}>
-        <Carousel inners={CarouselData} />
+        <DefaultCarousel inners={CarouselData} />
       </DefaultVStack>
 
       <TemplateCardList

--- a/apps/web/pages/templates/my.tsx
+++ b/apps/web/pages/templates/my.tsx
@@ -11,6 +11,41 @@ import { HeaderText } from '@ui/text';
 
 import { TemplateCardList } from '@templates/index';
 
+const templates = [
+  {
+    id: '1',
+    title: '템플릿1',
+    imageAlt: '템플릿1',
+    imageSrc: '/naver-login.svg',
+    createAt: '2022.01.08',
+    lastUpdateAt: '10분 전',
+  },
+  {
+    id: '2',
+    title: '템플릿1',
+    imageAlt: '템플릿1',
+    imageSrc: '/naver-login.svg',
+    createAt: '2022.01.08',
+    lastUpdateAt: '10분 전',
+  },
+  {
+    id: '3',
+    title: '템플릿1',
+    imageAlt: '템플릿1',
+    imageSrc: '/naver-login.svg',
+    createAt: '2022.01.08',
+    lastUpdateAt: '10분 전',
+  },
+  {
+    id: '4',
+    title: '템플릿1',
+    imageAlt: '템플릿1',
+    imageSrc: '/naver-login.svg',
+    createAt: '2022.01.08',
+    lastUpdateAt: '10분 전',
+  },
+];
+
 export default function My() {
   const theme = useTheme();
 
@@ -33,34 +68,16 @@ export default function My() {
         </DefaultHStack>
 
         <DefaultHStack justifyContent="space-between">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/kakao-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/logo.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/carousel-example.webp"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
+          {templates.map((template) => (
+            <MyTemplateCard
+              id={template.id}
+              title={template.title}
+              imageAlt={template.imageAlt}
+              imageSrc={template.imageSrc}
+              createAt={template.createAt}
+              lastUpdateAt={template.lastUpdateAt}
+            />
+          ))}
         </DefaultHStack>
       </DefaultVStack>
 

--- a/apps/web/pages/templates/my.tsx
+++ b/apps/web/pages/templates/my.tsx
@@ -4,10 +4,7 @@ import { useTheme } from '@emotion/react';
 
 import BaseLayout from 'layouts/BaseLayout';
 
-import { DefaultButton } from '@ui/button';
-import { MyTemplateCard } from '@ui/card';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
-import { HeaderText } from '@ui/text';
+import { DefaultButton, DefaultHStack, DefaultVStack, HeaderText, MyTemplateCard } from 'ui';
 
 import { TemplateCardList } from '@templates/index';
 

--- a/apps/web/pages/templates/task/start.tsx
+++ b/apps/web/pages/templates/task/start.tsx
@@ -4,9 +4,7 @@ import { useTheme } from '@emotion/react';
 
 import BaseLayout from 'layouts/BaseLayout';
 
-import { FreeSizeButton } from '@ui/button';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
-import { DefaultText } from '@ui/text';
+import { DefaultHStack, DefaultText, DefaultVStack, FreeSizeButton } from 'ui';
 
 const Buttons = [
   {

--- a/apps/web/templates/card-list/TemplateCardList.tsx
+++ b/apps/web/templates/card-list/TemplateCardList.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
-import { TemplateCard } from '@ui/card';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
+import { DefaultHStack, DefaultVStack, TemplateCard } from 'ui';
 
 interface TemplateCardListPropsInterface {
   title?: string;

--- a/apps/web/templates/form/ConfigForm.tsx
+++ b/apps/web/templates/form/ConfigForm.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { css, useTheme } from '@emotion/react';
 
-import { FormPropsInterface } from '@ui/form/types';
-import { Form } from 'ui';
+import { Form, FormPropsInterface } from 'ui';
 
 const configFormCSS = (color: string, border: string) => css`
   width: 420px;

--- a/apps/web/templates/form/FindTemplateSearchForm.tsx
+++ b/apps/web/templates/form/FindTemplateSearchForm.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { IconButton } from '@ui/button';
-import { SearchIcon } from '@ui/icon';
-import { DefaultInput } from '@ui/input';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
-import { DefaultText } from '@ui/text';
+import {
+  DefaultHStack,
+  DefaultInput,
+  DefaultText,
+  DefaultVStack,
+  IconButton,
+  SearchIcon,
+} from 'ui';
 
 export function FindTemplateSearchForm() {
   const theme = useTheme();

--- a/apps/web/templates/form/LoginForm.tsx
+++ b/apps/web/templates/form/LoginForm.tsx
@@ -10,14 +10,14 @@ import { useRouter } from 'next/router';
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { DefaultButtonPropsInterface } from '@ui/button/types';
-import { FormPropsInterface } from '@ui/form/types';
 import {
+  DefaultButtonPropsInterface,
   DefaultHStack,
   DefaultLink,
   DefaultText,
   Form,
   FormInput,
+  FormPropsInterface,
   FullWidthButton,
   LinkInterface,
   StrongText,

--- a/apps/web/templates/index.ts
+++ b/apps/web/templates/index.ts
@@ -2,3 +2,4 @@ export * from './form';
 export * from './link';
 export * from './button';
 export * from './card-list';
+export * from './modal';

--- a/apps/web/templates/modal/MyTemplateList.tsx
+++ b/apps/web/templates/modal/MyTemplateList.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { DefaultBox } from '@ui/Box';
-import { MyTemplateCard } from '@ui/card';
-import { DefaultHStack } from '@ui/stack';
+import { DefaultBox, DefaultHStack, MyTemplateCard } from 'ui';
 
 import { MytemplateListModalInnerPropsInterface } from './types';
 

--- a/apps/web/templates/modal/MyTemplateList.tsx
+++ b/apps/web/templates/modal/MyTemplateList.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { useTheme } from '@emotion/react';
+
+import { DefaultBox } from '@ui/Box';
+import { MyTemplateCard } from '@ui/card';
+import { DefaultHStack } from '@ui/stack';
+
+export function MyTemplateList() {
+  const theme = useTheme();
+  return (
+    <DefaultBox height="360px" border={theme.border.default} overflowY="scroll" width="60vw">
+      <DefaultHStack paddingRight="24px" display="flex" flexWrap="wrap">
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+          <MyTemplateCard
+            title="템플릿1"
+            imageAlt="템플릿1"
+            imageSrc="/naver-login.svg"
+            createAt="2022.01.08"
+            lastUpdateAt="10분 전"
+          />
+        </DefaultBox>
+      </DefaultHStack>
+    </DefaultBox>
+  );
+}

--- a/apps/web/templates/modal/MyTemplateList.tsx
+++ b/apps/web/templates/modal/MyTemplateList.tsx
@@ -6,65 +6,25 @@ import { DefaultBox } from '@ui/Box';
 import { MyTemplateCard } from '@ui/card';
 import { DefaultHStack } from '@ui/stack';
 
-export function MyTemplateList() {
+import { MytemplateListModalInnerPropsInterface } from './types';
+
+export function MyTemplateList({ templates }: MytemplateListModalInnerPropsInterface) {
   const theme = useTheme();
   return (
     <DefaultBox height="360px" border={theme.border.default} overflowY="scroll" width="60vw">
       <DefaultHStack paddingRight="24px" display="flex" flexWrap="wrap">
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
-        <DefaultBox paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
-          <MyTemplateCard
-            title="템플릿1"
-            imageAlt="템플릿1"
-            imageSrc="/naver-login.svg"
-            createAt="2022.01.08"
-            lastUpdateAt="10분 전"
-          />
-        </DefaultBox>
+        {templates.map((template) => (
+          <DefaultBox key={template.id} paddingTop="24px" paddingBottom="24px" paddingLeft="24px">
+            <MyTemplateCard
+              id={template.id}
+              title={template.title}
+              imageAlt={template.imageAlt}
+              imageSrc={template.imageSrc}
+              createAt={template.createAt}
+              lastUpdateAt={template.lastUpdateAt}
+            />
+          </DefaultBox>
+        ))}
       </DefaultHStack>
     </DefaultBox>
   );

--- a/apps/web/templates/modal/index.ts
+++ b/apps/web/templates/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './MyTemplateList';

--- a/apps/web/templates/modal/types.ts
+++ b/apps/web/templates/modal/types.ts
@@ -1,0 +1,5 @@
+import { MyTemplateCardPropsInterface } from '@ui/card';
+
+export interface MytemplateListModalInnerPropsInterface {
+  templates: MyTemplateCardPropsInterface[];
+}

--- a/apps/web/templates/modal/types.ts
+++ b/apps/web/templates/modal/types.ts
@@ -1,4 +1,4 @@
-import { MyTemplateCardPropsInterface } from '@ui/card';
+import { MyTemplateCardPropsInterface } from 'ui';
 
 export interface MytemplateListModalInnerPropsInterface {
   templates: MyTemplateCardPropsInterface[];

--- a/apps/web/tests/__tests__/pages/login.test.tsx
+++ b/apps/web/tests/__tests__/pages/login.test.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router';
 
 import LoginPage from '@pages/login';
 
-import { CustomThemeProvider } from '@ui/styles';
+import { CustomThemeProvider } from 'ui';
 
 import { LoginFormButton } from '@templates/form/LoginForm';
 

--- a/packages/common-hooks/index.ts
+++ b/packages/common-hooks/index.ts
@@ -4,3 +4,4 @@ export { useForm } from './useForm';
 export { useLocalStorage } from './useLocalStorage';
 export { useSessionStorage } from './useSessionStorage';
 export { useWindow } from './useWindow';
+export { useModal } from './useModal';

--- a/packages/common-hooks/useModal.ts
+++ b/packages/common-hooks/useModal.ts
@@ -1,0 +1,42 @@
+import { useRef, useState } from 'react';
+
+interface UseModalPropsInterface {
+  confirmCallback: () => void;
+  cancelCallback?: () => void;
+}
+export const useModal = ({ confirmCallback, cancelCallback }: UseModalPropsInterface) => {
+  const [visible, setVisible] = useState(false);
+
+  const confirmCallbackRef = useRef(confirmCallback);
+  const cancelCallbackRef = useRef(cancelCallback);
+
+  const onOpenModal = () => {
+    setVisible(() => true);
+  };
+
+  const onCloseModal = () => {
+    setVisible(() => false);
+  };
+
+  const onConfirmButtonClick = () => {
+    confirmCallbackRef.current();
+    setVisible(() => false);
+  };
+
+  const onCancelButtonClick = () => {
+    if (!cancelCallbackRef.current) {
+      return;
+    }
+
+    cancelCallbackRef.current();
+    setVisible(() => false);
+  };
+
+  return {
+    visible,
+    onOpenModal,
+    onCloseModal,
+    onConfirmButtonClick,
+    onCancelButtonClick,
+  };
+};

--- a/packages/common-hooks/useModal.ts
+++ b/packages/common-hooks/useModal.ts
@@ -5,7 +5,7 @@ interface UseModalPropsInterface {
   cancelCallback?: () => void;
 }
 export const useModal = ({ confirmCallback, cancelCallback }: UseModalPropsInterface) => {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(true);
 
   const confirmCallbackRef = useRef(confirmCallback);
   const cancelCallbackRef = useRef(cancelCallback);

--- a/packages/ui/Box/Default.tsx
+++ b/packages/ui/Box/Default.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { Box, BoxProps } from '@chakra-ui/react';
+
+export function DefaultBox({ children, ...props }: BoxProps) {
+  return <Box {...props}>{children}</Box>;
+}

--- a/packages/ui/Box/index.ts
+++ b/packages/ui/Box/index.ts
@@ -1,0 +1,1 @@
+export * from './Default';

--- a/packages/ui/button/Default.tsx
+++ b/packages/ui/button/Default.tsx
@@ -15,6 +15,7 @@ export function DefaultButton({
   children,
   disabled = false,
   onClick,
+  bg,
 }: DefaultButtonPropsInterface) {
   return (
     <Button
@@ -27,6 +28,7 @@ export function DefaultButton({
       isDisabled={disabled}
       onClick={onClick}
       variant={shape}
+      bg={bg}
     >
       {children}
     </Button>

--- a/packages/ui/button/index.ts
+++ b/packages/ui/button/index.ts
@@ -3,3 +3,4 @@ export { IconWithTextButton } from '@ui/button/IconWithText';
 export { FullWidthButton } from '@ui/button/FullWidth';
 export { IconButton } from '@ui/button/Icon';
 export { FreeSizeButton } from '@ui/button/FreeSizeButton';
+export type { DefaultButtonPropsInterface } from './types';

--- a/packages/ui/button/types.ts
+++ b/packages/ui/button/types.ts
@@ -20,6 +20,7 @@ export interface DefaultButtonPropsInterface extends ButtonInterface {
   width?: string;
   height?: string;
   loadingText?: string;
+  bg?: string;
 }
 
 export interface IconWithTextButtonPropsInterface extends DefaultButtonPropsInterface {

--- a/packages/ui/buttonGroup/ModalButtonGroup.tsx
+++ b/packages/ui/buttonGroup/ModalButtonGroup.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { useTheme } from '@emotion/react';
+
+import { DefaultBox } from '@ui/Box';
+import { DefaultButton } from '@ui/button/Default';
+import { DefaultHStack } from '@ui/stack';
+
+import { ModalButtonGroupPropsInterface } from './types';
+
+export function ModalButtonGroup({
+  onConfirmButtonClick,
+  onCancelButtonClick,
+}: ModalButtonGroupPropsInterface) {
+  const theme = useTheme();
+
+  return (
+    <DefaultBox display="flex" justifyContent="flex-end">
+      <DefaultHStack width="240px" justifyContent="space-between">
+        <DefaultButton width="108px" onClick={onConfirmButtonClick}>
+          네
+        </DefaultButton>
+        <DefaultButton width="108px" bg={theme.color.error} onClick={onCancelButtonClick}>
+          아니요
+        </DefaultButton>
+      </DefaultHStack>
+    </DefaultBox>
+  );
+}

--- a/packages/ui/buttonGroup/index.ts
+++ b/packages/ui/buttonGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './ModalButtonGroup';

--- a/packages/ui/buttonGroup/types.ts
+++ b/packages/ui/buttonGroup/types.ts
@@ -1,0 +1,4 @@
+export interface ModalButtonGroupPropsInterface {
+  onConfirmButtonClick: () => void;
+  onCancelButtonClick: () => void;
+}

--- a/packages/ui/card/my-template-card/MyTemplateCard.tsx
+++ b/packages/ui/card/my-template-card/MyTemplateCard.tsx
@@ -44,7 +44,7 @@ export function MyTemplateCard({
       overflow="hidden"
       position="relative"
       transition={'all 0.2s'}
-      width="220px"
+      width="219px"
       height="180px"
       border={theme.border.default}
       borderRadius={theme.borderRadius.soft}

--- a/packages/ui/card/my-template-card/MyTemplateCard.tsx
+++ b/packages/ui/card/my-template-card/MyTemplateCard.tsx
@@ -10,7 +10,8 @@ import { DefaultText } from '@ui/text';
 
 import { MyTemplateCardDetailBoxCSS, StyledMyTemplateCardContainer } from './styles';
 
-interface MyTemplateCardPropsInterface {
+export interface MyTemplateCardPropsInterface {
+  id: string;
   imageSrc: string;
   imageAlt: string;
   title: string;
@@ -31,6 +32,7 @@ const StyledImage = styled(Image)`
 `;
 
 export function MyTemplateCard({
+  id,
   imageSrc,
   imageAlt,
   title,
@@ -40,6 +42,7 @@ export function MyTemplateCard({
   const theme = useTheme();
   return (
     <StyledMyTemplateCardContainer
+      id={id}
       padding="0"
       overflow="hidden"
       position="relative"

--- a/packages/ui/carousel/Carousel.tsx
+++ b/packages/ui/carousel/Carousel.tsx
@@ -33,7 +33,7 @@ const StyledImage = styled(Image)`
   object-position: right;
 `;
 
-export default function Carousel({ inners }: CarouselPropsInterface) {
+export function DefaultCarousel({ inners }: CarouselPropsInterface) {
   const reginedInners = useMemo<CarouselInnerInterface[]>(
     () => [
       { ...inners.at(-1), id: 'prev' } as CarouselInnerInterface,

--- a/packages/ui/form/index.ts
+++ b/packages/ui/form/index.ts
@@ -1,1 +1,2 @@
 export { Form } from './Form';
+export type { FormPropsInterface } from './types';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -16,3 +16,4 @@ export * from '@ui/card';
 export * from '@ui/carousel';
 export * from '@ui/divider';
 export * from '@ui/tooltip';
+export * from '@ui/modal';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -17,3 +17,4 @@ export * from '@ui/carousel';
 export * from '@ui/divider';
 export * from '@ui/tooltip';
 export * from '@ui/modal';
+export * from '@ui/Box';

--- a/packages/ui/modal/Confirm.tsx
+++ b/packages/ui/modal/Confirm.tsx
@@ -1,11 +1,10 @@
 import React, { ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { DefaultButton } from '@ui/button';
-import { DefaultHStack, DefaultVStack } from '@ui/stack';
+import { ModalButtonGroup } from '@ui/buttonGroup';
+import { DefaultVStack } from '@ui/stack';
 import { DefaultText } from '@ui/text';
 
 import { useMounted } from '@common-hooks/useMounted';
@@ -17,6 +16,8 @@ interface StyledModalContainerInterface {
 interface ModalPropsInterface extends StyledModalContainerInterface {
   title: ReactNode;
   descriptions: string[];
+  onConfirmButtonClick: () => void;
+  onCancelButtonClick: () => void;
 }
 
 const ModalBackgroundDim = styled.div`
@@ -41,8 +42,13 @@ const StyledModalContainer = styled.div<StyledModalContainerInterface>`
   opacity: 1;
 `;
 
-export default function Modal({ width = 'auto', title, descriptions }: ModalPropsInterface) {
-  const theme = useTheme();
+export default function Modal({
+  width = 'auto',
+  title,
+  descriptions,
+  onConfirmButtonClick,
+  onCancelButtonClick,
+}: ModalPropsInterface) {
   const mounted = useMounted();
 
   const root = useRef<HTMLElement | null>(null);
@@ -63,12 +69,10 @@ export default function Modal({ width = 'auto', title, descriptions }: ModalProp
                 ))}
               </DefaultVStack>
 
-              <DefaultHStack width="240px" justifyContent="space-between">
-                <DefaultButton width="108px">네</DefaultButton>
-                <DefaultButton width="108px" bg={theme.color.error}>
-                  아니요
-                </DefaultButton>
-              </DefaultHStack>
+              <ModalButtonGroup
+                onConfirmButtonClick={onConfirmButtonClick}
+                onCancelButtonClick={onCancelButtonClick}
+              />
             </DefaultVStack>
           </StyledModalContainer>
         </ModalBackgroundDim>,

--- a/packages/ui/modal/Confirm.tsx
+++ b/packages/ui/modal/Confirm.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { ModalButtonGroup } from '@ui/buttonGroup';
@@ -9,18 +10,13 @@ import { DefaultText } from '@ui/text';
 
 import { useMounted } from '@common-hooks/useMounted';
 
-interface StyledModalContainerInterface {
-  width?: string;
-}
+import {
+  ModalPropsInterface,
+  StyledBackgroundDimInterface,
+  StyledModalContainerInterface,
+} from './types';
 
-interface ModalPropsInterface extends StyledModalContainerInterface {
-  title: ReactNode;
-  descriptions: string[];
-  onConfirmButtonClick: () => void;
-  onCancelButtonClick: () => void;
-}
-
-const ModalBackgroundDim = styled.div`
+const ModalBackgroundDim = styled.div<StyledBackgroundDimInterface>`
   position: fixed;
   top: 0;
   right: 0;
@@ -31,7 +27,14 @@ const ModalBackgroundDim = styled.div`
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.75);
+
+  ${({ visible }) =>
+    !visible &&
+    css`
+      display: none;
+    `}
 `;
+
 const StyledModalContainer = styled.div<StyledModalContainerInterface>`
   width: ${({ width }) => width};
   min-width: 304px;
@@ -43,9 +46,11 @@ const StyledModalContainer = styled.div<StyledModalContainerInterface>`
 `;
 
 export default function Modal({
+  visible = false,
   width = 'auto',
   title,
   descriptions,
+  children,
   onConfirmButtonClick,
   onCancelButtonClick,
 }: ModalPropsInterface) {
@@ -59,7 +64,7 @@ export default function Modal({
 
   return mounted
     ? createPortal(
-        <ModalBackgroundDim>
+        <ModalBackgroundDim visible={visible}>
           <StyledModalContainer width={width}>
             <DefaultVStack spacing={5}>
               <DefaultVStack textAlign="center" spacing={2}>
@@ -68,6 +73,8 @@ export default function Modal({
                   <DefaultText key={idx}>{description}</DefaultText>
                 ))}
               </DefaultVStack>
+
+              {children}
 
               <ModalButtonGroup
                 onConfirmButtonClick={onConfirmButtonClick}

--- a/packages/ui/modal/Confirm.tsx
+++ b/packages/ui/modal/Confirm.tsx
@@ -1,0 +1,78 @@
+import React, { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { DefaultButton } from '@ui/button';
+import { DefaultHStack, DefaultVStack } from '@ui/stack';
+import { DefaultText } from '@ui/text';
+
+import { useMounted } from '@common-hooks/useMounted';
+
+interface StyledModalContainerInterface {
+  width?: string;
+}
+
+interface ModalPropsInterface extends StyledModalContainerInterface {
+  title: ReactNode;
+  descriptions: string[];
+}
+
+const ModalBackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+`;
+const StyledModalContainer = styled.div<StyledModalContainerInterface>`
+  width: ${({ width }) => width};
+  min-width: 304px;
+  padding: 20px 32px;
+  background-color: white;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  border-radius: 20px;
+  opacity: 1;
+`;
+
+export default function Modal({ width = 'auto', title, descriptions }: ModalPropsInterface) {
+  const theme = useTheme();
+  const mounted = useMounted();
+
+  const root = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    root.current = document.querySelector('body');
+  }, []);
+
+  return mounted
+    ? createPortal(
+        <ModalBackgroundDim>
+          <StyledModalContainer width={width}>
+            <DefaultVStack spacing={5}>
+              <DefaultVStack textAlign="center" spacing={2}>
+                <h6>{title}</h6>
+                {descriptions.map((description, idx) => (
+                  <DefaultText key={idx}>{description}</DefaultText>
+                ))}
+              </DefaultVStack>
+
+              <DefaultHStack width="240px" justifyContent="space-between">
+                <DefaultButton width="108px">네</DefaultButton>
+                <DefaultButton width="108px" bg={theme.color.error}>
+                  아니요
+                </DefaultButton>
+              </DefaultHStack>
+            </DefaultVStack>
+          </StyledModalContainer>
+        </ModalBackgroundDim>,
+        root.current as HTMLElement
+      )
+    : null;
+}

--- a/packages/ui/modal/Default.tsx
+++ b/packages/ui/modal/Default.tsx
@@ -1,3 +1,5 @@
+import { useMounted } from 'common-hooks';
+
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -7,8 +9,6 @@ import styled from '@emotion/styled';
 import { ModalButtonGroup } from '@ui/buttonGroup';
 import { DefaultVStack } from '@ui/stack';
 import { DefaultText } from '@ui/text';
-
-import { useMounted } from '@common-hooks/useMounted';
 
 import {
   ModalPropsInterface,
@@ -45,7 +45,7 @@ const StyledModalContainer = styled.div<StyledModalContainerInterface>`
   opacity: 1;
 `;
 
-export default function Modal({
+export function DefaultModal({
   visible = false,
   width = 'auto',
   title,

--- a/packages/ui/modal/index.ts
+++ b/packages/ui/modal/index.ts
@@ -1,0 +1,1 @@
+export * from './Confirm';

--- a/packages/ui/modal/index.ts
+++ b/packages/ui/modal/index.ts
@@ -1,1 +1,1 @@
-export * from './Confirm';
+export * from './Default';

--- a/packages/ui/modal/types.ts
+++ b/packages/ui/modal/types.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export interface StyledBackgroundDimInterface {
+  visible: boolean;
+}
+export interface StyledModalContainerInterface {
+  width?: string;
+}
+
+export interface ModalPropsInterface
+  extends StyledBackgroundDimInterface,
+    StyledModalContainerInterface {
+  children?: ReactNode;
+  title: string;
+  descriptions: ReactNode[];
+
+  onConfirmButtonClick: () => void;
+  onCancelButtonClick: () => void;
+}

--- a/packages/ui/text/Default.tsx
+++ b/packages/ui/text/Default.tsx
@@ -7,7 +7,7 @@ import { globalTheme } from '@ui/styles';
 
 interface StyledTextInterface {
   as?: 'p' | 'span' | 'div';
-  textAlign?: 'left' | 'center' | 'right';
+  textAlign?: 'left' | 'center' | 'right' | 'inherit';
   size?: string;
   color?: string;
   visible?: boolean;
@@ -42,7 +42,7 @@ export function DefaultText({
   as = 'span',
   visible = true,
   size = globalTheme.fontSize.md,
-  textAlign = 'left',
+  textAlign = 'inherit',
   children,
   color = globalTheme.color.text,
   ariaLabel,

--- a/packages/ui/toast/index.ts
+++ b/packages/ui/toast/index.ts
@@ -1,3 +1,4 @@
 export { StyledToastBoxList } from './styles';
 export * from './Box';
 export * from './BoxListTop';
+export type { ToastBoxInterface } from './types';


### PR DESCRIPTION
## 💌 설명

TemplateModal을 구현했다.
가장 바깥쪽은 추상적으로 공통되는 인터페이스로 설계하여 언제든지 안의 `Inner`에 따라 유동적으로 바뀔 수 있도록 설정했다.

또한 공통되는 상태 관리를 위해 `useModal`이라는 커스텀 훅 역시 추가했다.
이를 통해 더이상 복잡하게 일일이 모달의 상태를 적지 않아도 된다.

마지막으로 이러한 모달의 경우 화면 위에 떠있기 때문에 많은 양의 정보가 주어진다면 클 수록 좋다고 판단했다.
이유는, 사용자가 큰 화면임에도 불구하고 모달이 작아버리면, 일일이 찾는데 피로도가 증가하기 때문이다.

따라서 직접 `width`를 설정하지 않는 이상, 약 `60vw`의 크기에서 템플릿이 모니터 크기만큼 보일 수 있도록 했다.
아래는 예시이다.

<img width="1503" alt="image" src="https://user-images.githubusercontent.com/78713176/211994941-ebc67131-4f6d-4446-b1a0-3920291180de.png">

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/78713176/211994995-6ad6e2b3-65a2-4563-87fa-ec2779ff06e8.png">

위와 같이 보이는 레이아웃은 일관성이 있지만, 사용자의 모니터 크기에 따라 유동적으로 레이아웃은 조정된다.
`max-width`는 아직 고민이어서 걸지는 않았지만, 결과적으로 좀 더 유연하게 UX를 개선했다고 생각한다! 

## 📎 관련 이슈

closes #46

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
