### PR TITLE
ShapeBlock, ImageBlock, TextBlock의 공통적인 로직을 추출하여 커스텀 훅으로 분리한다

### DIFF
--- a/apps/web/atoms/index.ts
+++ b/apps/web/atoms/index.ts
@@ -13,3 +13,5 @@ export { resizablePageAtom } from './resizablePageAtom';
 export { templateCreateToolbarAtom, initialBlockCreationState } from './templateCreateToolbarAtom';
 
 export { toastAtom } from './toastAtom';
+
+export { mouseStateAtom } from './mouseStateAtom';

--- a/apps/web/atoms/mouseStateAtom.ts
+++ b/apps/web/atoms/mouseStateAtom.ts
@@ -1,0 +1,15 @@
+import { atom } from 'jotai';
+
+type MouseStateAtomPosition = number;
+
+export interface MouseStateAtomInterface {
+  moveActived: boolean;
+  x: MouseStateAtomPosition;
+  y: MouseStateAtomPosition;
+}
+
+export const mouseStateAtom = atom<MouseStateAtomInterface>({
+  moveActived: false,
+  x: 0,
+  y: 0,
+});

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -10,3 +10,5 @@ export { usePageDB, getTaskHistories } from './usePageDB';
 
 /* eslint-disable-next-line import/no-cycle */
 export { useTemplateTaskHistories } from './useTemplateTaskHistories';
+
+export { useBlockGroupMove } from './useBlockGroupMove';

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -14,3 +14,6 @@ export { useTemplateTaskHistories } from './useTemplateTaskHistories';
 export { usePageDB, getTaskHistories } from './usePageDB';
 
 export { useMouseStateAtom } from './useMouseStateAtom';
+
+/* eslint-disable-next-line import/no-cycle */
+export { useSearchActiveBlockGroup } from './useSearchActiveBlockGroup';

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -1,14 +1,16 @@
 export { useToast } from './useToast';
+
+export { useTemplateCreateToolbar } from './useTemplateCreateToolbar';
+
+export { useResizablePageAtom } from './useResizablePageAtom';
+
 export { useCreateBlockGroupsStore } from './useCreateBlockGroupsStore';
 export { useBlockGroupsAtom } from './useBlockGroupsAtom';
 export { useBorderMatrix } from './useBorderMatrix';
 export { useBorderModifier } from './useBorderModifier';
-export { useResizablePageAtom } from './useResizablePageAtom';
-export { useTemplateCreateToolbar } from './useTemplateCreateToolbar';
+export { useBlockGroupMove } from './useBlockGroupMove';
 
+export { useTemplateTaskHistories } from './useTemplateTaskHistories';
 export { usePageDB, getTaskHistories } from './usePageDB';
 
-/* eslint-disable-next-line import/no-cycle */
-export { useTemplateTaskHistories } from './useTemplateTaskHistories';
-
-export { useBlockGroupMove } from './useBlockGroupMove';
+export { useMouseStateAtom } from './useMouseStateAtom';

--- a/apps/web/hooks/types.ts
+++ b/apps/web/hooks/types.ts
@@ -1,0 +1,5 @@
+import { BlockGroupPriorities, Blocks } from 'ui';
+
+export interface UseLeafParams<T = Blocks> extends BlockGroupPriorities {
+  data: T;
+}

--- a/apps/web/hooks/useBlockGroupMove.ts
+++ b/apps/web/hooks/useBlockGroupMove.ts
@@ -1,0 +1,158 @@
+/**
+ * NOTE: 추후 pnpm이 모노레포를 원활히 지원한다면 제거한다.
+ */
+import type {} from 'node_modules/@types/react';
+
+import { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from 'react';
+
+import { convertPxStringToNumber } from '@utils/index';
+
+import { BlockGroupPriorities, Blocks, Position } from 'ui';
+
+import { useBlockGroupsAtom } from './useBlockGroupsAtom';
+import { useResizablePageAtom } from './useResizablePageAtom';
+import { useTemplateTaskHistories } from './useTemplateTaskHistories';
+
+interface UseBlockMoveParams<T = Blocks> extends BlockGroupPriorities {
+  data: T;
+}
+export const useBlockGroupMove = ({ data, depth, order }: UseBlockMoveParams) => {
+  const { pageState } = useResizablePageAtom();
+
+  const { addTask } = useTemplateTaskHistories();
+
+  const { setActiveId, changeBlockState } = useBlockGroupsAtom();
+
+  const [isPossibleMove, setIsPossibleMove] = useState(false);
+
+  const [lastOffset, setLastOffset] = useState({
+    top: 0,
+    left: 0,
+  });
+
+  const updatedPosition = useRef<{ top: Position['top'] | null; left: Position['left'] | null }>({
+    top: null,
+    left: null,
+  });
+
+  const onMouseDown = (e: ReactMouseEvent) => {
+    setActiveId('block', data.id, depth, order);
+    const { clientX, clientY } = e;
+
+    setLastOffset((state) => ({
+      ...state,
+      left: clientX - +pageState.left - convertPxStringToNumber(data.style.position.left),
+      top:
+        pageState.scrollY -
+        +pageState.top +
+        clientY -
+        convertPxStringToNumber(data.style.position.top),
+    }));
+
+    setIsPossibleMove(() => true);
+  };
+
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!boxRef.current) return;
+
+    const mouseDownHandler = (e: MouseEvent) => {
+      if (!isPossibleMove) return;
+
+      const { clientX, clientY } = e;
+      const nowLeft = clientX - +pageState.left - lastOffset.left;
+      const nowTop = pageState.scrollY - +pageState.top + clientY - lastOffset.top;
+
+      updatedPosition.current.left = nowLeft + 'px';
+      updatedPosition.current.top = nowTop + 'px';
+
+      if (data.subType !== 'text') {
+        changeBlockState({
+          ...data,
+          style: {
+            ...data.style,
+            position: {
+              ...data.style.position,
+              left: nowLeft + 'px',
+              top: nowTop + 'px',
+            },
+          },
+        });
+      } else {
+        changeBlockState({
+          ...data,
+          style: {
+            ...data.style,
+            position: {
+              ...data.style.position,
+              left: nowLeft + 'px',
+              top: nowTop + 'px',
+            },
+          },
+        });
+      }
+    };
+
+    window.addEventListener('mousemove', mouseDownHandler, {
+      passive: true,
+    });
+
+    return () => {
+      window.removeEventListener('mousemove', mouseDownHandler);
+    };
+
+    /* eslint-disable-next-line */
+  }, [boxRef, isPossibleMove]);
+
+  const onMouseUp = () => {
+    if (!updatedPosition.current.left || !updatedPosition.current.top) return;
+
+    if (isPossibleMove) {
+      if (data.subType === 'text') {
+        addTask({
+          taskType: 'update',
+          before: data,
+          after: {
+            ...data,
+            style: {
+              ...data.style,
+              position: {
+                ...data.style.position,
+                left: updatedPosition.current.left,
+                top: updatedPosition.current.top,
+              },
+            },
+          },
+        });
+      } else {
+        addTask({
+          taskType: 'update',
+          before: data,
+          after: {
+            ...data,
+            style: {
+              ...data.style,
+              position: {
+                ...data.style.position,
+                left: updatedPosition.current.left,
+                top: updatedPosition.current.top,
+              },
+            },
+          },
+        });
+      }
+
+      updatedPosition.current.top = null;
+      updatedPosition.current.left = null;
+    }
+
+    setIsPossibleMove(() => false);
+  };
+
+  return {
+    boxRef,
+    onMouseUp,
+    onMouseDown,
+  };
+};

--- a/apps/web/hooks/useBlockGroupsAtom.ts
+++ b/apps/web/hooks/useBlockGroupsAtom.ts
@@ -336,12 +336,25 @@ export const useBlockGroupsAtom = () => {
   const deleteBlock = (block: Blocks) => {
     setBlockGroupState((state) => {
       const nextState = { ...state.blocksStore };
-
       delete nextState[block.id];
+
+      const parentId = block.parent;
+      const parentState = parentId ? state.groupsStore[parentId] : null;
 
       return {
         ...state,
         blocksStore: nextState,
+        groupsStore: {
+          ...state.groupsStore,
+          ...(parentId && parentState
+            ? {
+                [parentId]: {
+                  ...parentState,
+                  blocks: parentState.blocks.filter((v) => v.id !== block.id),
+                },
+              }
+            : {}),
+        },
       };
     });
   };

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -4,7 +4,7 @@ import { useAtom } from 'jotai';
 
 import { mouseStateAtom } from '@atoms/index';
 
-import { throttle } from '@utils/throttle';
+import { throttle } from '@utils/index';
 
 export const useMouseStateAtom = () => {
   const [mouseState, setMouseState] = useAtom(mouseStateAtom);

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { mouseStateAtom } from '@atoms/index';
 
+import { throttle } from '@utils/throttle';
+
 export const useMouseStateAtom = () => {
   const [mouseState, setMouseState] = useAtom(mouseStateAtom);
 
@@ -24,7 +26,7 @@ export const useMouseStateAtom = () => {
   };
 
   useEffect(() => {
-    const mouseMoveHandler = (e: MouseEvent) => {
+    const mouseMoveHandler = throttle((e: MouseEvent) => {
       const { clientX, clientY } = e;
 
       setMouseState((state) => ({
@@ -32,10 +34,10 @@ export const useMouseStateAtom = () => {
         x: clientX,
         y: clientY,
       }));
-    };
+    }, 20);
 
     if (mouseState.moveActived) {
-      document.body.addEventListener('mousemove', mouseMoveHandler, { passive: true });
+      document.body.addEventListener('mousemove', mouseMoveHandler);
     }
 
     return () => {

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+import { useAtom } from 'jotai';
+
+import { mouseStateAtom } from '@atoms/index';
+
+export const useMouseStateAtom = () => {
+  const [mouseState, setMouseState] = useAtom(mouseStateAtom);
+
+  const activeMouseMove = (x: number, y: number) => {
+    setMouseState(() => ({
+      moveActived: true,
+      x,
+      y,
+    }));
+  };
+
+  const inactiveMouseMove = () => {
+    setMouseState(() => ({
+      moveActived: false,
+      x: 0,
+      y: 0,
+    }));
+  };
+
+  useEffect(() => {
+    const mouseMoveHandler = (e: MouseEvent) => {
+      const { clientX, clientY } = e;
+
+      setMouseState((state) => ({
+        ...state,
+        x: clientX,
+        y: clientY,
+      }));
+    };
+
+    if (mouseState.moveActived) {
+      document.body.addEventListener('mousemove', mouseMoveHandler, { passive: true });
+    }
+
+    return () => {
+      document.body.removeEventListener('mousemove', mouseMoveHandler);
+    };
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [mouseState.moveActived]);
+
+  return { mouseState, activeMouseMove, inactiveMouseMove };
+};

--- a/apps/web/hooks/useResizablePageAtom.tsx
+++ b/apps/web/hooks/useResizablePageAtom.tsx
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai';
 
 import { resizablePageAtom } from '@atoms/index';
 
+import { throttle } from '@utils/index';
+
 import { SizeType } from 'ui';
 
 interface UseResizablePageParams {
@@ -54,12 +56,12 @@ export const useResizablePageAtom = () => {
   };
 
   useEffect(() => {
-    const scrollHandler = () => {
+    const scrollHandler = throttle(() => {
       setResizablePageState((state) => ({
         ...state,
         scrollY: window.scrollY,
       }));
-    };
+    }, 20);
 
     window.addEventListener('scroll', scrollHandler, { passive: true });
 

--- a/apps/web/hooks/useSearchActiveBlockGroup.ts
+++ b/apps/web/hooks/useSearchActiveBlockGroup.ts
@@ -1,0 +1,43 @@
+import { MouseEvent as ReactMouseEvent } from 'react';
+
+import { useBlockGroupsAtom } from '@hooks/index';
+
+import { Blocks } from 'ui';
+
+import { UseLeafParams } from './types';
+
+export const useSearchActiveBlockGroup = <T extends Blocks>({
+  data,
+  depth,
+  order,
+}: UseLeafParams<T>) => {
+  const { setActiveId, setNextActivedBlockGroup, setToggleTrue } = useBlockGroupsAtom();
+
+  /**
+   * @see: feat(component): set click event to active block or group
+   */
+  const onActiveTarget = (e: ReactMouseEvent) => {
+    e.stopPropagation();
+    setActiveId('block', data.id, depth, order);
+  };
+
+  /**
+   * @description
+   * 더블클릭 시 속해 있는 하위 블록/그룹에 접근할 수 있도록 했다.
+   *
+   * @see: feat(component): set click event to active block or group
+   */
+  const onSearchNextTarget = (e: ReactMouseEvent) => {
+    e.stopPropagation();
+
+    setNextActivedBlockGroup({ type: 'group', id: data.id, depth, order });
+    if (data.parent) {
+      setToggleTrue(data.parent);
+    }
+  };
+
+  return {
+    onActiveTarget,
+    onSearchNextTarget,
+  };
+};

--- a/apps/web/libs/utils/index.ts
+++ b/apps/web/libs/utils/index.ts
@@ -3,3 +3,4 @@ export * from './errors';
 export * from './contants';
 export * from './validate';
 export * from './schemas';
+export * from './throttle';

--- a/apps/web/libs/utils/throttle.ts
+++ b/apps/web/libs/utils/throttle.ts
@@ -1,0 +1,12 @@
+export const throttle = <E extends Event>(cb: (e: E, ...args: unknown[]) => void, delay = 300) => {
+  let timerFunc: null | NodeJS.Timeout = null;
+
+  return (e: E, ...args: unknown[]) => {
+    if (timerFunc) return;
+
+    timerFunc = setTimeout(() => {
+      cb(e, ...args);
+      timerFunc = null;
+    }, delay);
+  };
+};

--- a/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
+++ b/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
@@ -1,6 +1,7 @@
-import React, { MouseEvent as ReactMouseEvent } from 'react';
+import React from 'react';
 
 import { useBlockGroupMove, useBlockGroupsAtom } from '@hooks/index';
+import { useSearchActiveBlockGroup } from '@hooks/useSearchActiveBlockGroup';
 
 import { BlockGroupPriorities, DefaultBox, ShapeBlock } from 'ui';
 
@@ -13,28 +14,13 @@ interface ShapeLeafPropsInterface extends BlockGroupPriorities {
 export function ShapeLeaf({ data, depth, order }: ShapeLeafPropsInterface) {
   const { activeId, setHoverId, initializeHoverBlockGroup } = useBlockGroupsAtom();
 
-  const { setActiveId, setNextActivedBlockGroup, setToggleTrue } = useBlockGroupsAtom();
+  const { onActiveTarget, onSearchNextTarget } = useSearchActiveBlockGroup<ShapeBlock>({
+    data,
+    depth,
+    order,
+  });
 
-  /**
-   * @see: feat(component): set click event to active block or group
-   */
-  const onClickLeaf = (e: ReactMouseEvent) => {
-    e.stopPropagation();
-    setActiveId('block', data.id, depth, order);
-  };
-
-  const { boxRef, onMouseDown, onMouseUp } = useBlockGroupMove({ data, depth, order });
-
-  /**
-   * @see: feat(component): set click event to active block or group
-   */
-  const onDoubleClickLeaf = (e: ReactMouseEvent) => {
-    e.stopPropagation();
-    setNextActivedBlockGroup({ type: 'group', id: data.id, depth, order });
-    if (data.parent) {
-      setToggleTrue(data.parent);
-    }
-  };
+  const { boxRef, onMouseDown, onMouseUp } = useBlockGroupMove({ data });
 
   return (
     <DefaultBox
@@ -76,10 +62,10 @@ export function ShapeLeaf({ data, depth, order }: ShapeLeafPropsInterface) {
       data-order={order}
       onMouseOver={() => setHoverId({ id: data.id, depth, order })}
       onMouseLeave={() => initializeHoverBlockGroup()}
-      onClick={onClickLeaf}
+      onClick={onActiveTarget}
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
-      onDoubleClick={onDoubleClickLeaf}
+      onDoubleClick={onSearchNextTarget}
     >
       {activeId === data.id && <Updator item={data} />}
     </DefaultBox>

--- a/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
+++ b/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { useBlockGroupMove, useBlockGroupsAtom } from '@hooks/index';
-import { useSearchActiveBlockGroup } from '@hooks/useSearchActiveBlockGroup';
+import { useBlockGroupMove, useBlockGroupsAtom, useSearchActiveBlockGroup } from '@hooks/index';
 
 import { BlockGroupPriorities, DefaultBox, ShapeBlock } from 'ui';
 


### PR DESCRIPTION
## 💌 설명

mouse 이벤트에 관한 최적화 역시 부분적으로 진행했다.
`throttle`을 활용하여 Block 내의 `mousemove`, `scroll` 이벤트를 최적화했다.
단위는, 체감상 약 0.02가 가장 자연스러웠다. (아무래도 세밀한 컨트롤을 요하는 작업이다보니, UX의 역치가 상당히 낮아 단위를 크게 잡을 수 없었다.)

확실히 뭔가 빨라진 느낌이 들었다!
실제로 같은 행위를 콘솔로 찍어봤을 때 어림잡아 약 50%의 성능이 개선되었다.

## 📎 관련 이슈

closes #74
#76 

## 💡 논의해볼 사항

### mouseMoveAtom

결국 `mousemove`하는 로직이 반복되는데, 내가 알기로는 `e.clientX`등의 마우스 정보는 리플로우를 유발하는 것으로 알고 있다.
따라서 이를 최대한 같은 곳에서 사용할 수 있도록 전역에서 상태관리를 하는 아이디어를 떠올렸다.
다만, 이러한 `mousemove`가 동작하지 않을 때에는 이벤트 하나가 쓸 데 없이 생성되는 문제가 있다.
따라서 `mouseState.moveActived`라는 프로퍼티를 추가하여, 이 프로퍼티가 `true`일 때만 이벤트를 추가하는 것으로 최적화했다.

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
