### PR TITLE
MouseEvent의 순서에 따라 발생하는 이벤트 캡쳐링/버블링으로 인한 복잡한 로직을 개선한다

### DIFF
--- a/apps/web/atoms/blockBorderAtom.ts
+++ b/apps/web/atoms/blockBorderAtom.ts
@@ -3,54 +3,50 @@ import { atom } from 'jotai';
 import {
   BorderName,
   Directions,
-  DirectionsContstants,
+  DirectionsConstants,
   EdgeDirections,
-  EdgeDirectionsContstants,
+  EdgeDirectionsConstants,
 } from 'ui';
 
 export interface BlockBorderStateAtomInterface {
   activeBorder: Directions | EdgeDirections | 'all';
-  concurrentlyActivedSection: (EdgeDirectionsContstants | DirectionsContstants)[];
+  concurrentlyActivedSection: (EdgeDirectionsConstants | DirectionsConstants)[];
   name: BorderName;
 }
 
 export const concurrentlyActivedSections = {
   all: [
-    DirectionsContstants.top,
-    DirectionsContstants.bottom,
-    DirectionsContstants.left,
-    DirectionsContstants.right,
-    EdgeDirectionsContstants.topLeft,
-    EdgeDirectionsContstants.topRight,
-    EdgeDirectionsContstants.bottomLeft,
-    EdgeDirectionsContstants.bottomRight,
+    DirectionsConstants.top,
+    DirectionsConstants.bottom,
+    DirectionsConstants.left,
+    DirectionsConstants.right,
+    EdgeDirectionsConstants.topLeft,
+    EdgeDirectionsConstants.topRight,
+    EdgeDirectionsConstants.bottomLeft,
+    EdgeDirectionsConstants.bottomRight,
   ],
 
-  top: [
-    DirectionsContstants.top,
-    EdgeDirectionsContstants.topLeft,
-    EdgeDirectionsContstants.topRight,
-  ],
+  top: [DirectionsConstants.top, EdgeDirectionsConstants.topLeft, EdgeDirectionsConstants.topRight],
   bottom: [
-    DirectionsContstants.bottom,
-    EdgeDirectionsContstants.bottomLeft,
-    EdgeDirectionsContstants.bottomRight,
+    DirectionsConstants.bottom,
+    EdgeDirectionsConstants.bottomLeft,
+    EdgeDirectionsConstants.bottomRight,
   ],
   left: [
-    DirectionsContstants.left,
-    EdgeDirectionsContstants.topLeft,
-    EdgeDirectionsContstants.bottomLeft,
+    DirectionsConstants.left,
+    EdgeDirectionsConstants.topLeft,
+    EdgeDirectionsConstants.bottomLeft,
   ],
   right: [
-    DirectionsContstants.right,
-    EdgeDirectionsContstants.topRight,
-    EdgeDirectionsContstants.bottomRight,
+    DirectionsConstants.right,
+    EdgeDirectionsConstants.topRight,
+    EdgeDirectionsConstants.bottomRight,
   ],
 
-  topLeft: [EdgeDirectionsContstants.topLeft],
-  topRight: [EdgeDirectionsContstants.topRight],
-  bottomLeft: [EdgeDirectionsContstants.bottomLeft],
-  bottomRight: [EdgeDirectionsContstants.bottomRight],
+  topLeft: [EdgeDirectionsConstants.topLeft],
+  topRight: [EdgeDirectionsConstants.topRight],
+  bottomLeft: [EdgeDirectionsConstants.bottomLeft],
+  bottomRight: [EdgeDirectionsConstants.bottomRight],
 };
 
 export const blockBorderStateAtom = atom<BlockBorderStateAtomInterface>({

--- a/apps/web/atoms/index.ts
+++ b/apps/web/atoms/index.ts
@@ -14,4 +14,5 @@ export { templateCreateToolbarAtom, initialBlockCreationState } from './template
 
 export { toastAtom } from './toastAtom';
 
+export type { MouseStateAtomInterface } from './mouseStateAtom';
 export { mouseStateAtom } from './mouseStateAtom';

--- a/apps/web/atoms/mouseStateAtom.ts
+++ b/apps/web/atoms/mouseStateAtom.ts
@@ -6,10 +6,12 @@ export interface MouseStateAtomInterface {
   moveActived: boolean;
   x: MouseStateAtomPosition;
   y: MouseStateAtomPosition;
+  throttle: boolean;
 }
 
 export const mouseStateAtom = atom<MouseStateAtomInterface>({
   moveActived: false,
   x: 0,
   y: 0,
+  throttle: true,
 });

--- a/apps/web/hooks/useBorderMatrix.ts
+++ b/apps/web/hooks/useBorderMatrix.ts
@@ -4,7 +4,7 @@ import { blockBorderStateAtom, concurrentlyActivedSections } from '@atoms/index'
 
 import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
 
-import { BorderName, DirectionsContstants, EdgeDirectionsContstants } from 'ui';
+import { BorderName, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
 
 export const useBorderMatrix = () => {
   const [blockBorderState, setBlockBorderState] = useAtom(blockBorderStateAtom);
@@ -26,8 +26,8 @@ export const useBorderMatrix = () => {
     };
 
     blockBorderState.concurrentlyActivedSection.forEach((concurrentlyActivedDirection) => {
-      if (concurrentlyActivedDirection in EdgeDirectionsContstants) {
-        nextBorderRadius[concurrentlyActivedDirection as EdgeDirectionsContstants] = value;
+      if (concurrentlyActivedDirection in EdgeDirectionsConstants) {
+        nextBorderRadius[concurrentlyActivedDirection as EdgeDirectionsConstants] = value;
       }
     });
 
@@ -42,7 +42,7 @@ export const useBorderMatrix = () => {
   const onClickBorderSection = ({
     key,
   }: {
-    key: EdgeDirectionsContstants | DirectionsContstants | 'all';
+    key: EdgeDirectionsConstants | DirectionsConstants | 'all';
   }) => {
     setBlockBorderState((state) => ({
       ...state,

--- a/apps/web/hooks/useBorderModifier.ts
+++ b/apps/web/hooks/useBorderModifier.ts
@@ -1,6 +1,6 @@
 import { FormEvent } from 'react';
 
-import { Border, DirectionsContstants, EdgeDirectionsContstants } from 'ui';
+import { Border, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
 
 import { useBlockGroupsAtom } from './useBlockGroupsAtom';
 import { useBorderMatrix } from './useBorderMatrix';
@@ -41,13 +41,13 @@ export const useBorderModifier = () => {
     const targetObj = activedBlockGroup.style[key];
 
     const concurrentlyActivedEdges = blockBorderState.concurrentlyActivedSection.filter(
-      (v) => v in EdgeDirectionsContstants
+      (v) => v in EdgeDirectionsConstants
     );
 
-    const nowStandardValue = targetObj[concurrentlyActivedEdges[0] as EdgeDirectionsContstants];
+    const nowStandardValue = targetObj[concurrentlyActivedEdges[0] as EdgeDirectionsConstants];
 
     return {
-      success: (concurrentlyActivedEdges as EdgeDirectionsContstants[]).every(
+      success: (concurrentlyActivedEdges as EdgeDirectionsConstants[]).every(
         (key) => targetObj[key] === nowStandardValue
       ),
       value: nowStandardValue,
@@ -55,7 +55,7 @@ export const useBorderModifier = () => {
   };
 
   const activeSectionBorderWidth = () => {
-    if (blockBorderState.activeBorder in EdgeDirectionsContstants) return '';
+    if (blockBorderState.activeBorder in EdgeDirectionsConstants) return '';
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return '';
 
     if (blockBorderState.activeBorder === 'all') {
@@ -65,13 +65,13 @@ export const useBorderModifier = () => {
         return 'mixed';
       }
     } else {
-      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsContstants]
+      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsConstants]
         .width;
     }
   };
 
   const activeSectionBorderColor = () => {
-    if (blockBorderState.activeBorder in EdgeDirectionsContstants) return '';
+    if (blockBorderState.activeBorder in EdgeDirectionsConstants) return '';
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return '';
 
     if (blockBorderState.activeBorder === 'all') {
@@ -81,13 +81,13 @@ export const useBorderModifier = () => {
         return 'mixed';
       }
     } else {
-      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsContstants]
+      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsConstants]
         .color;
     }
   };
 
   const activeSectionBorderStyle = () => {
-    if (blockBorderState.activeBorder in EdgeDirectionsContstants) return '';
+    if (blockBorderState.activeBorder in EdgeDirectionsConstants) return '';
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return '';
 
     if (blockBorderState.activeBorder === 'all') {
@@ -97,13 +97,13 @@ export const useBorderModifier = () => {
         return 'mixed';
       }
     } else {
-      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsContstants]
+      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsConstants]
         .style;
     }
   };
 
   const activeSectionBorderOpacity = () => {
-    if (blockBorderState.activeBorder in EdgeDirectionsContstants) return '';
+    if (blockBorderState.activeBorder in EdgeDirectionsConstants) return '';
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return '';
 
     if (blockBorderState.activeBorder === 'all') {
@@ -113,7 +113,7 @@ export const useBorderModifier = () => {
         return 'mixed';
       }
     } else {
-      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsContstants]
+      return activedBlockGroup.style.border[blockBorderState.activeBorder as DirectionsConstants]
         .opacity;
     }
   };
@@ -128,7 +128,7 @@ export const useBorderModifier = () => {
       } else {
         return 'mixed';
       }
-    } else if (blockBorderState.activeBorder in DirectionsContstants) {
+    } else if (blockBorderState.activeBorder in DirectionsConstants) {
       const { success, value } = checkEdgeValuesConditionalEqual('borderRadius');
 
       if (success) {
@@ -137,7 +137,7 @@ export const useBorderModifier = () => {
         return 'mixed';
       }
     } else {
-      return borderRadius[blockBorderState.activeBorder as EdgeDirectionsContstants];
+      return borderRadius[blockBorderState.activeBorder as EdgeDirectionsConstants];
     }
   };
 
@@ -173,12 +173,12 @@ export const useBorderModifier = () => {
       setBlockAllBorderStyle({ type: 'block', id: activedBlockGroup.id, border: nextBorderState });
     } else {
       if (type === 'width') {
-        if (blockBorderState.activeBorder in DirectionsContstants) {
+        if (blockBorderState.activeBorder in DirectionsConstants) {
           setBlockBorderWidth({
             subType: activedBlockGroup.subType,
             type: activedBlockGroup.type,
             id: activedBlockGroup.id,
-            key: blockBorderState.activeBorder as DirectionsContstants,
+            key: blockBorderState.activeBorder as DirectionsConstants,
             borderWidth: value,
           });
         }
@@ -189,7 +189,7 @@ export const useBorderModifier = () => {
           subType: activedBlockGroup.subType,
           type: activedBlockGroup.type,
           id: activedBlockGroup.id,
-          key: blockBorderState.activeBorder as DirectionsContstants,
+          key: blockBorderState.activeBorder as DirectionsConstants,
           borderColor: value,
         });
       }
@@ -199,7 +199,7 @@ export const useBorderModifier = () => {
           subType: activedBlockGroup.subType,
           type: activedBlockGroup.type,
           id: activedBlockGroup.id,
-          key: blockBorderState.activeBorder as DirectionsContstants,
+          key: blockBorderState.activeBorder as DirectionsConstants,
           borderStyle: value as Border['style'],
         });
       }
@@ -209,7 +209,7 @@ export const useBorderModifier = () => {
           subType: activedBlockGroup.subType,
           type: activedBlockGroup.type,
           id: activedBlockGroup.id,
-          key: blockBorderState.activeBorder as DirectionsContstants,
+          key: blockBorderState.activeBorder as DirectionsConstants,
           borderOpacity: value,
         });
       }
@@ -234,14 +234,14 @@ export const useBorderModifier = () => {
       nextBorderRadius.bottomLeft = value;
       nextBorderRadius.bottomRight = value;
     } else {
-      if (blockBorderState.activeBorder in DirectionsContstants) {
+      if (blockBorderState.activeBorder in DirectionsConstants) {
         blockBorderState.concurrentlyActivedSection.forEach((section) => {
-          if (section in EdgeDirectionsContstants) {
-            nextBorderRadius[section as EdgeDirectionsContstants] = value;
+          if (section in EdgeDirectionsConstants) {
+            nextBorderRadius[section as EdgeDirectionsConstants] = value;
           }
         });
       } else {
-        nextBorderRadius[blockBorderState.activeBorder as EdgeDirectionsContstants] = value;
+        nextBorderRadius[blockBorderState.activeBorder as EdgeDirectionsConstants] = value;
       }
     }
 

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -2,23 +2,30 @@ import { useEffect } from 'react';
 
 import { useAtom } from 'jotai';
 
-import { mouseStateAtom } from '@atoms/index';
+import { MouseStateAtomInterface, mouseStateAtom } from '@atoms/index';
 
 import { throttle } from '@utils/index';
 
 export const useMouseStateAtom = () => {
   const [mouseState, setMouseState] = useAtom(mouseStateAtom);
 
-  const activeMouseMove = (x: number, y: number) => {
-    setMouseState(() => ({
+  const activeMouseMove = (
+    x: number,
+    y: number,
+    options: Pick<MouseStateAtomInterface, 'throttle'>
+  ) => {
+    setMouseState((state) => ({
+      ...state,
       moveActived: true,
       x,
       y,
+      ...options,
     }));
   };
 
   const inactiveMouseMove = () => {
-    setMouseState(() => ({
+    setMouseState((state) => ({
+      ...state,
       moveActived: false,
       x: 0,
       y: 0,
@@ -26,7 +33,7 @@ export const useMouseStateAtom = () => {
   };
 
   useEffect(() => {
-    const mouseMoveHandler = throttle((e: MouseEvent) => {
+    const mouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
       setMouseState((state) => ({
@@ -34,10 +41,14 @@ export const useMouseStateAtom = () => {
         x: clientX,
         y: clientY,
       }));
-    }, 20);
+    };
 
     if (mouseState.moveActived) {
-      document.body.addEventListener('mousemove', mouseMoveHandler);
+      document.body.addEventListener(
+        'mousemove',
+        mouseState.throttle ? throttle(mouseMoveHandler, 10) : mouseMoveHandler,
+        { passive: true }
+      );
     }
 
     return () => {

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -12,14 +12,14 @@ export const useMouseStateAtom = () => {
   const activeMouseMove = (
     x: number,
     y: number,
-    options: Pick<MouseStateAtomInterface, 'throttle'>
+    options?: Pick<MouseStateAtomInterface, 'throttle'>
   ) => {
     setMouseState((state) => ({
       ...state,
       moveActived: true,
       x,
       y,
-      ...options,
+      ...(options ?? {}),
     }));
   };
 

--- a/apps/web/hooks/useMouseStateAtom.ts
+++ b/apps/web/hooks/useMouseStateAtom.ts
@@ -9,6 +9,12 @@ import { throttle } from '@utils/index';
 export const useMouseStateAtom = () => {
   const [mouseState, setMouseState] = useAtom(mouseStateAtom);
 
+  /**
+   * @param
+   * options: {
+   *  throttle: boolean(default: true)
+   * }
+   */
   const activeMouseMove = (
     x: number,
     y: number,

--- a/apps/web/templates/layouts/sidebar/right/border-modifier/Matrix.tsx
+++ b/apps/web/templates/layouts/sidebar/right/border-modifier/Matrix.tsx
@@ -11,17 +11,17 @@ import {
   DefaultHStack,
   DefaultText,
   DefaultVStack,
-  DirectionsContstants,
-  EdgeDirectionsContstants,
+  DirectionsConstants,
+  EdgeDirectionsConstants,
   StrongText,
 } from 'ui';
 
 interface SubMatrixCommonPropsInterface {
-  onMouseOverMatrix: (key: EdgeDirectionsContstants | DirectionsContstants | 'all') => void;
+  onMouseOverMatrix: (key: EdgeDirectionsConstants | DirectionsConstants | 'all') => void;
   onClickBorderSection: ({
     key,
   }: {
-    key: EdgeDirectionsContstants | DirectionsContstants | 'all';
+    key: EdgeDirectionsConstants | DirectionsConstants | 'all';
   }) => void;
   onBlurMatrix: () => void;
 }
@@ -29,12 +29,12 @@ interface SubMatrixCommonPropsInterface {
 interface LineMatrixPropsInterface extends SubMatrixCommonPropsInterface {
   direction: 'vertical' | 'horizontal';
   actived: boolean;
-  position: DirectionsContstants;
+  position: DirectionsConstants;
 }
 
 interface EdgeMatrixPropsInterface extends SubMatrixCommonPropsInterface {
   actived: boolean;
-  position: EdgeDirectionsContstants;
+  position: EdgeDirectionsConstants;
 }
 
 const initialmatrixState = {
@@ -65,9 +65,9 @@ const EdgeMatrix = ({
       backgroundColor={actived ? theme.color.primary[500] : theme.color.transparent}
       transition="all 0.2s"
       cursor="pointer"
-      onMouseOver={() => onMouseOverMatrix(EdgeDirectionsContstants[position])}
+      onMouseOver={() => onMouseOverMatrix(EdgeDirectionsConstants[position])}
       onMouseLeave={onBlurMatrix}
-      onClick={() => onClickBorderSection({ key: EdgeDirectionsContstants[position] })}
+      onClick={() => onClickBorderSection({ key: EdgeDirectionsConstants[position] })}
     />
   );
 };
@@ -100,9 +100,9 @@ const LineMatrix = ({
       backgroundColor={actived ? theme.color.primary[500] : theme.color.transparent}
       transition="all 0.2s"
       cursor="pointer"
-      onMouseOver={() => onMouseOverMatrix(DirectionsContstants[position])}
+      onMouseOver={() => onMouseOverMatrix(DirectionsConstants[position])}
       onMouseLeave={onBlurMatrix}
-      onClick={() => onClickBorderSection({ key: DirectionsContstants[position] })}
+      onClick={() => onClickBorderSection({ key: DirectionsConstants[position] })}
     >
       <DefaultText textAlign="center" size={theme.fontSize.xs} color={theme.color.white}>
         {BorderName[position]}
@@ -135,7 +135,7 @@ export function BorderMatrix() {
     setActiveSections();
   }, [setActiveSections]);
 
-  const onMouseOverMatrix = (key: EdgeDirectionsContstants | DirectionsContstants | 'all') => {
+  const onMouseOverMatrix = (key: EdgeDirectionsConstants | DirectionsConstants | 'all') => {
     const nextState = { ...initialmatrixState };
 
     const concurrencies = concurrentlyActivedSections[key];
@@ -160,8 +160,8 @@ export function BorderMatrix() {
       <DefaultVStack>
         <DefaultHStack>
           <EdgeMatrix
-            actived={activedState[EdgeDirectionsContstants.topLeft]}
-            position={EdgeDirectionsContstants.topLeft}
+            actived={activedState[EdgeDirectionsConstants.topLeft]}
+            position={EdgeDirectionsConstants.topLeft}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
@@ -169,16 +169,16 @@ export function BorderMatrix() {
 
           <LineMatrix
             direction="horizontal"
-            actived={activedState[DirectionsContstants.top]}
-            position={DirectionsContstants.top}
+            actived={activedState[DirectionsConstants.top]}
+            position={DirectionsConstants.top}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
           />
 
           <EdgeMatrix
-            actived={activedState[EdgeDirectionsContstants.topRight]}
-            position={EdgeDirectionsContstants.topRight}
+            actived={activedState[EdgeDirectionsConstants.topRight]}
+            position={EdgeDirectionsConstants.topRight}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
@@ -188,8 +188,8 @@ export function BorderMatrix() {
         <DefaultHStack>
           <LineMatrix
             direction="vertical"
-            actived={activedState[DirectionsContstants.left]}
-            position={DirectionsContstants.left}
+            actived={activedState[DirectionsConstants.left]}
+            position={DirectionsConstants.left}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
@@ -207,8 +207,8 @@ export function BorderMatrix() {
 
           <LineMatrix
             direction="vertical"
-            actived={activedState[DirectionsContstants.right]}
-            position={DirectionsContstants.right}
+            actived={activedState[DirectionsConstants.right]}
+            position={DirectionsConstants.right}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
@@ -217,8 +217,8 @@ export function BorderMatrix() {
 
         <DefaultHStack>
           <EdgeMatrix
-            actived={activedState[EdgeDirectionsContstants.bottomLeft]}
-            position={EdgeDirectionsContstants.bottomLeft}
+            actived={activedState[EdgeDirectionsConstants.bottomLeft]}
+            position={EdgeDirectionsConstants.bottomLeft}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
@@ -226,16 +226,16 @@ export function BorderMatrix() {
 
           <LineMatrix
             direction="horizontal"
-            actived={activedState[DirectionsContstants.bottom]}
-            position={DirectionsContstants.bottom}
+            actived={activedState[DirectionsConstants.bottom]}
+            position={DirectionsConstants.bottom}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}
           />
 
           <EdgeMatrix
-            actived={activedState[EdgeDirectionsContstants.bottomRight]}
-            position={EdgeDirectionsContstants.bottomRight}
+            actived={activedState[EdgeDirectionsConstants.bottomRight]}
+            position={EdgeDirectionsConstants.bottomRight}
             onMouseOverMatrix={onMouseOverMatrix}
             onBlurMatrix={onBlurMatrix}
             onClickBorderSection={onClickBorderSection}

--- a/apps/web/templates/layouts/sidebar/right/border-modifier/SubModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/border-modifier/SubModifier.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useBorderMatrix, useBorderModifier } from '@hooks/index';
 
-import { DefaultHStack, DefaultVStack, EdgeDirectionsContstants } from 'ui';
+import { DefaultHStack, DefaultVStack, EdgeDirectionsConstants } from 'ui';
 
 import { TemplatedColorInputWithTitlePresenter } from '../TemplatedColorInputWithTitle';
 import { TemplatedInputWithTitlePresenter } from '../TemplatedInputWithTitlePresenter';
@@ -15,7 +15,7 @@ import { TemplatedInputWithTitlePresenter } from '../TemplatedInputWithTitlePres
 export function BorderSubModifierFactory() {
   const { blockBorderState } = useBorderMatrix();
 
-  return blockBorderState.activeBorder in EdgeDirectionsContstants ? (
+  return blockBorderState.activeBorder in EdgeDirectionsConstants ? (
     <EdgeModifier />
   ) : (
     <LineModifier />

--- a/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
+++ b/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
@@ -4,7 +4,7 @@ import { useBlockGroupMove, useBlockGroupsAtom, useSearchActiveBlockGroup } from
 
 import { BlockGroupPriorities, DefaultBox, ShapeBlock } from 'ui';
 
-import { Updator } from './updator/Updator';
+import { Updator } from './updator';
 
 interface ShapeLeafPropsInterface extends BlockGroupPriorities {
   data: ShapeBlock;

--- a/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
+++ b/apps/web/templates/template-create/block-groups/ShapeLeaf.tsx
@@ -4,7 +4,7 @@ import { useBlockGroupMove, useBlockGroupsAtom, useSearchActiveBlockGroup } from
 
 import { BlockGroupPriorities, DefaultBox, ShapeBlock } from 'ui';
 
-import { Updator } from './Updator';
+import { Updator } from './updator/Updator';
 
 interface ShapeLeafPropsInterface extends BlockGroupPriorities {
   data: ShapeBlock;

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -244,6 +244,71 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
   };
 
+  const getNextFromRight = (x: number): { nextLeft: number; nextRight: number } => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
+      return {
+        nextLeft: 0,
+        nextRight: 0,
+      };
+    }
+
+    const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
+    const nowRight = x - +pageState.left;
+
+    const isReversed = nowRight < activedBlockLeft;
+
+    return {
+      nextLeft: isReversed ? nowRight : activedBlockLeft,
+      nextRight: isReversed ? activedBlockLeft : nowRight,
+    };
+  };
+
+  const getNextFromBottom = (y: number): { nextTop: number; nextBottom: number } => {
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') {
+      return {
+        nextTop: 0,
+        nextBottom: 0,
+      };
+    }
+    const nextTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
+
+    const nextBottom = y + pageState.scrollY - +pageState.top;
+
+    const isReversed = nextBottom < nextTop;
+
+    return {
+      nextTop: isReversed ? nextBottom : nextTop,
+      nextBottom: isReversed ? nextTop : nextBottom,
+    };
+  };
+
+  const getNextFromLeft = (x: number): { nextLeft: number; nextRight: number } => {
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') {
+      return {
+        nextLeft: 0,
+        nextRight: 0,
+      };
+    }
+
+    const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
+    const activedBlockWidth = convertPxStringToNumber(activedBlockGroup.style.size.width);
+    const activedRightLineFromLeft = activedBlockWidth + activedBlockLeft;
+
+    const pageLeft = +pageState.left;
+
+    const nowLeft = x - pageLeft;
+
+    const isReversed = nowLeft > activedRightLineFromLeft;
+
+    const nextLeft = isReversed ? activedRightLineFromLeft : nowLeft;
+    const nextRight = isReversed ? nowLeft : activedRightLineFromLeft;
+
+    return {
+      nextLeft,
+      nextRight,
+    };
+  };
+
   useEffect(() => {
     const lineTopMouseMoveHandler = (e: MouseEvent) => {
       if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -297,25 +362,6 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
     /* eslint-disable-next-line */
   }, [isUpdating]);
-
-  const getNextFromBottom = (y: number) => {
-    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') {
-      return {
-        nextTop: 0,
-        nextBottom: 0,
-      };
-    }
-    const nextTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-
-    const nextBottom = y + pageState.scrollY - +pageState.top;
-
-    const isReversed = nextBottom < nextTop;
-
-    return {
-      nextTop: isReversed ? nextBottom : nextTop,
-      nextBottom: isReversed ? nextTop : nextBottom,
-    };
-  };
 
   useEffect(() => {
     const lineBottomMouseMoveHandler = (e: MouseEvent) => {
@@ -377,18 +423,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
       const { clientX } = e;
 
-      const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
-      const activedBlockWidth = convertPxStringToNumber(activedBlockGroup.style.size.width);
-      const activedRightLineFromLeft = activedBlockWidth + activedBlockLeft;
-
-      const pageLeft = +pageState.left;
-
-      const nowLeft = clientX - pageLeft;
-
-      const isReversed = nowLeft > activedRightLineFromLeft;
-
-      const nextLeft = isReversed ? activedRightLineFromLeft : nowLeft;
-      const nextRight = isReversed ? nowLeft : activedRightLineFromLeft;
+      const { nextLeft, nextRight } = getNextFromLeft(clientX);
 
       const nextWidth = nextRight - nextLeft;
 
@@ -435,25 +470,6 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
     /* eslint-disable-next-line */
   }, [isUpdating]);
-
-  const getNextFromRight = (x: number): { nextLeft: number; nextRight: number } => {
-    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
-      return {
-        nextLeft: 0,
-        nextRight: 0,
-      };
-    }
-
-    const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
-    const nowRight = x - +pageState.left;
-
-    const isReversed = nowRight < activedBlockLeft;
-
-    return {
-      nextLeft: isReversed ? nowRight : activedBlockLeft,
-      nextRight: isReversed ? activedBlockLeft : nowRight,
-    };
-  };
 
   useEffect(() => {
     const lineRightMouseMoveHandler = (e: MouseEvent) => {

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -376,7 +376,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating, getNextFromRight]);
+  }, [isUpdating, pageState]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -405,7 +405,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating, getNextFromBottom]);
+  }, [isUpdating, pageState]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -436,7 +436,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating, getNextFromLeft]);
+  }, [isUpdating, pageState]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
@@ -475,7 +475,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating, getNextFromRight]);
+  }, [isUpdating, pageState]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -510,7 +510,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating]);
+  }, [isUpdating, pageState.scrollY]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -545,7 +545,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating]);
+  }, [isUpdating, pageState.scrollY]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -580,7 +580,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating]);
+  }, [isUpdating, pageState.scrollY]);
 
   useEffect(() => {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -615,7 +615,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
 
     /* eslint-disable-next-line */
-  }, [isUpdating]);
+  }, [isUpdating, pageState.scrollY]);
 
   return (
     <>

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -541,31 +541,11 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     const edgesBottomLeftMouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-      const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
-      const activedBlockWidth = convertPxStringToNumber(activedBlockGroup.style.size.width);
-      const activedBlocHeight = convertPxStringToNumber(activedBlockGroup.style.size.height);
-      const activedBlockRightLineFromLeft = activedBlockLeft + activedBlockWidth;
-      const activedBlockBottomLineFromTop = activedBlockTop + activedBlocHeight;
+      const { nextTop, nextBottom } = getNextFromTop(clientY);
+      const { nextLeft, nextRight } = getNextFromLeft(clientX);
 
-      const pageScrollY = pageState.scrollY;
-      const pageTop = +pageState.top;
-      const pageLeft = +pageState.left;
-
-      const nowTop = pageScrollY - pageTop + clientY;
-      const nowLeft = clientX - pageLeft;
-
-      const isTopReversed = activedBlockBottomLineFromTop < nowTop;
-      const isLeftReversed = activedBlockRightLineFromLeft < nowLeft;
-
-      const nextLeft = isLeftReversed ? activedBlockRightLineFromLeft : nowLeft;
-      const nextRightLineFormLeft = isLeftReversed ? nowLeft : activedBlockRightLineFromLeft;
-
-      const nextTop = isTopReversed ? activedBlockBottomLineFromTop : nowTop;
-      const nextBottomLineFromTop = isTopReversed ? nowTop : activedBlockBottomLineFromTop;
-
-      const nextWidth = nextRightLineFormLeft - nextLeft;
-      const nextHeight = nextBottomLineFromTop - nextTop;
+      const nextWidth = nextRight - nextLeft;
+      const nextHeight = nextBottom - nextTop;
 
       const nextSize = {
         ...activedBlockGroup.style.size,
@@ -620,30 +600,11 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     const edgeTopRightMouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-      const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
-      const activedBlocHeight = convertPxStringToNumber(activedBlockGroup.style.size.height);
+      const { nextTop, nextBottom } = getNextFromTop(clientY);
+      const { nextLeft, nextRight } = getNextFromRight(clientX);
 
-      const activedBlockBottomLineFromTop = activedBlockTop + activedBlocHeight;
-
-      const pageScrollY = pageState.scrollY;
-      const pageTop = +pageState.top;
-      const pageLeft = +pageState.left;
-
-      const nowTop = pageScrollY - pageTop + clientY;
-      const nowRightFromLeft = clientX - pageLeft;
-
-      const isTopReversed = activedBlockBottomLineFromTop < nowTop;
-      const isRightReversed = nowRightFromLeft < activedBlockLeft;
-
-      const nextLeft = isRightReversed ? nowRightFromLeft : activedBlockLeft;
-      const nextRightLineFormLeft = isRightReversed ? activedBlockLeft : nowRightFromLeft;
-
-      const nextTop = isTopReversed ? activedBlockBottomLineFromTop : nowTop;
-      const nextBottomLineFromTop = isTopReversed ? nowTop : activedBlockBottomLineFromTop;
-
-      const nextWidth = nextRightLineFormLeft - nextLeft;
-      const nextHeight = nextBottomLineFromTop - nextTop;
+      const nextWidth = nextRight - nextLeft;
+      const nextHeight = nextBottom - nextTop;
 
       if (activedBlockGroup.subType !== 'text') {
         const nextState = {
@@ -702,27 +663,11 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     const edgeBottomRightMouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-      const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
+      const { nextTop, nextBottom } = getNextFromBottom(clientY);
+      const { nextLeft, nextRight } = getNextFromRight(clientX);
 
-      const pageScrollY = pageState.scrollY;
-      const pageTop = +pageState.top;
-      const pageLeft = +pageState.left;
-
-      const nowBottomFromTop = pageScrollY - pageTop + clientY;
-      const nowRightFromLeft = clientX - pageLeft;
-
-      const isBottomReversed = nowBottomFromTop < activedBlockTop;
-      const isRightReversed = nowRightFromLeft < activedBlockLeft;
-
-      const nextLeft = isRightReversed ? nowRightFromLeft : activedBlockLeft;
-      const nextRightLineFormLeft = isRightReversed ? activedBlockLeft : nowRightFromLeft;
-
-      const nextTop = isBottomReversed ? nowBottomFromTop : activedBlockTop;
-      const nextBottomLineFromTop = isBottomReversed ? activedBlockTop : nowBottomFromTop;
-
-      const nextWidth = nextRightLineFormLeft - nextLeft;
-      const nextHeight = nextBottomLineFromTop - nextTop;
+      const nextWidth = nextRight - nextLeft;
+      const nextHeight = nextBottom - nextTop;
 
       const nextSize = {
         ...activedBlockGroup.style.size,
@@ -777,29 +722,11 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     const edgesBottomLeftMouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-      const activedBlockLeft = convertPxStringToNumber(activedBlockGroup.style.position.left);
-      const activedBlockWidth = convertPxStringToNumber(activedBlockGroup.style.size.width);
-      const activedBlockRightLineFromLeft = activedBlockLeft + activedBlockWidth;
+      const { nextTop, nextBottom } = getNextFromBottom(clientY);
+      const { nextLeft, nextRight } = getNextFromLeft(clientX);
 
-      const pageScrollY = pageState.scrollY;
-      const pageTop = +pageState.top;
-      const pageLeft = +pageState.left;
-
-      const nowBottomFromTop = pageScrollY - pageTop + clientY;
-      const nowLeft = clientX - pageLeft;
-
-      const isBottomReversed = nowBottomFromTop < activedBlockTop;
-      const isLeftReversed = activedBlockRightLineFromLeft < nowLeft;
-
-      const nextLeft = isLeftReversed ? activedBlockRightLineFromLeft : nowLeft;
-      const nextRightLineFormLeft = isLeftReversed ? nowLeft : activedBlockRightLineFromLeft;
-
-      const nextTop = isBottomReversed ? nowBottomFromTop : activedBlockTop;
-      const nextBottomLineFromTop = isBottomReversed ? activedBlockTop : nowBottomFromTop;
-
-      const nextWidth = nextRightLineFormLeft - nextLeft;
-      const nextHeight = nextBottomLineFromTop - nextTop;
+      const nextWidth = nextRight - nextLeft;
+      const nextHeight = nextBottom - nextTop;
 
       const nextSize = {
         ...activedBlockGroup.style.size,

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -222,6 +222,28 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     setNowUpdate(() => null);
   };
 
+  const getNextFromTop = (y: number): { nextTop: number; nextBottom: number } => {
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') {
+      return {
+        nextTop: 0,
+        nextBottom: 0,
+      };
+    }
+
+    const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
+    const activedBlockHeight = convertPxStringToNumber(activedBlockGroup.style.size.height);
+
+    const nextTop = y - +pageState.top + pageState.scrollY;
+    const nextBottom = activedBlockHeight + activedBlockTop;
+
+    const isReversed = nextTop > nextBottom;
+
+    return {
+      nextTop: isReversed ? nextBottom : nextTop,
+      nextBottom: isReversed ? nextTop : nextBottom,
+    };
+  };
+
   useEffect(() => {
     const lineTopMouseMoveHandler = (e: MouseEvent) => {
       if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -229,23 +251,17 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
       const { clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-      const activedBlockHeight = convertPxStringToNumber(activedBlockGroup.style.size.height);
-      const activedBlockBottom = activedBlockTop + activedBlockHeight;
-
-      const nextTop = clientY - +pageState.top + pageState.scrollY;
-      const nextHeight = activedBlockHeight + activedBlockTop - nextTop;
-
-      const isReversed = nextTop > activedBlockBottom;
+      const { nextTop, nextBottom } = getNextFromTop(clientY);
+      const nextHeight = nextBottom - nextTop;
 
       const nextPosition = {
         ...activedBlockGroup.style.position,
-        top: (isReversed ? activedBlockBottom : nextTop) + 'px',
+        top: nextTop + 'px',
       };
 
       const nextSize = {
         ...activedBlockGroup.style.size,
-        height: (isReversed ? nextTop - activedBlockBottom : nextHeight) + 'px',
+        height: nextHeight + 'px',
       };
 
       if (activedBlockGroup.subType !== 'text') {
@@ -405,7 +421,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     /* eslint-disable-next-line */
   }, [isUpdating]);
 
-  const getNextFromRight = (x: number) => {
+  const getNextFromRight = (x: number): { nextLeft: number; nextRight: number } => {
     if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
       return {
         nextLeft: 0,

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -231,51 +231,27 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     setNowUpdate(() => null);
   };
 
-  const getActiveBlockNextSize = (props: Partial<GroupBlockSize>): GroupBlockSize => {
-    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
-      return {
-        width: 'auto',
-        height: 'auto',
-      };
-    }
-
-    return {
-      ...activedBlockGroup.style.size,
-      ...props,
-    };
-  };
-
-  const getActiveBlockNextPosition = (props: Partial<Position>): Position => {
-    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
-      return {
-        top: 'auto',
-        right: 'auto',
-        bottom: 'auto',
-        left: 'auto',
-      };
-    }
-
-    return {
-      ...activedBlockGroup.style.position,
-      ...props,
-    };
-  };
-
   const getActiveBlockNextState = ({
     block,
-    nextSize,
-    nextPosition,
+    nextSize = {},
+    nextPosition = {},
   }: {
     block: Blocks;
-    nextSize: GroupBlockSize;
-    nextPosition: Position;
+    nextSize: Partial<GroupBlockSize>;
+    nextPosition: Partial<Position>;
   }) => {
     return {
       ...block,
       style: {
         ...block.style,
-        size: nextSize,
-        position: nextPosition,
+        size: {
+          ...block.style.size,
+          ...nextSize,
+        },
+        position: {
+          ...block.style.position,
+          ...nextPosition,
+        },
       },
     };
   };
@@ -368,22 +344,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   };
 
   useEffect(() => {
-    const lineTopMouseMoveHandler = (e: MouseEvent) => {
-      if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
-      if (!isUpdating.top) return;
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
+    if (!isUpdating.top) return;
 
+    const lineTopMouseMoveHandler = (e: MouseEvent) => {
       const { clientY } = e;
 
       const { nextTop, nextBottom } = getNextFromTop(clientY);
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = getActiveBlockNextSize({ height: nextHeight + 'px' });
-      const nextPosition = getActiveBlockNextPosition({ top: nextTop + 'px' });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { height: nextHeight + 'px' },
+        nextPosition: { top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -403,21 +376,18 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   }, [isUpdating]);
 
   useEffect(() => {
-    const lineBottomMouseMoveHandler = (e: MouseEvent) => {
-      if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
-      if (!isUpdating.bottom) return;
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
+    if (!isUpdating.bottom) return;
 
+    const lineBottomMouseMoveHandler = (e: MouseEvent) => {
       const { clientY } = e;
 
       const { nextTop, nextBottom } = getNextFromBottom(clientY);
 
-      const nextSize = getActiveBlockNextSize({ height: nextBottom - nextTop + 'px' });
-      const nextPosition = getActiveBlockNextPosition({ top: nextTop + 'px' });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { height: nextBottom - nextTop + 'px' },
+        nextPosition: { top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -437,23 +407,20 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   }, [isUpdating]);
 
   useEffect(() => {
-    const lineLeftMouseMoveHandler = (e: MouseEvent) => {
-      if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
-      if (!isUpdating.left) return;
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
+    if (!isUpdating.left) return;
 
+    const lineLeftMouseMoveHandler = (e: MouseEvent) => {
       const { clientX } = e;
 
       const { nextLeft, nextRight } = getNextFromLeft(clientX);
 
       const nextWidth = nextRight - nextLeft;
 
-      const nextSize = getActiveBlockNextSize({ width: nextWidth + 'px' });
-      const nextPosition = getActiveBlockNextPosition({ left: nextLeft + 'px' });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px' },
+        nextPosition: { left: nextLeft + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -473,10 +440,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   }, [isUpdating]);
 
   useEffect(() => {
-    const lineRightMouseMoveHandler = (e: MouseEvent) => {
-      if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
-      if (!isUpdating.right) return;
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+    if (!isUpdating.right) return;
 
+    const lineRightMouseMoveHandler = (e: MouseEvent) => {
       /**
        * @inner
        * useMouseStateAtom으로 하지 않는 이유는, 현재 이벤트에서 가져오는 값이 훨씬 속도가 빠르기 때문이다.
@@ -491,13 +458,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const { nextLeft, nextRight } = getNextFromRight(clientX);
       const nextWidth = nextRight - nextLeft;
 
-      const nextSize = getActiveBlockNextSize({ width: nextWidth + 'px' });
-      const nextPosition = getActiveBlockNextPosition({ left: nextLeft + 'px' });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px' },
+        nextPosition: { left: nextLeft + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -529,19 +493,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = getActiveBlockNextSize({
-        width: nextWidth + 'px',
-        height: nextHeight + 'px',
-      });
-      const nextPosition = getActiveBlockNextPosition({
-        left: nextLeft + 'px',
-        top: nextTop + 'px',
-      });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px', height: nextHeight + 'px' },
+        nextPosition: { left: nextLeft + 'px', top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -573,20 +528,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = getActiveBlockNextSize({
-        width: nextWidth + 'px',
-        height: nextHeight + 'px',
-      });
-
-      const nextPosition = getActiveBlockNextPosition({
-        left: nextLeft + 'px',
-        top: nextTop + 'px',
-      });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px', height: nextHeight + 'px' },
+        nextPosition: { left: nextLeft + 'px', top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -618,19 +563,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = getActiveBlockNextSize({
-        width: nextWidth + 'px',
-        height: nextHeight + 'px',
-      });
-      const nextPosition = getActiveBlockNextPosition({
-        left: nextLeft + 'px',
-        top: nextTop + 'px',
-      });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px', height: nextHeight + 'px' },
+        nextPosition: { left: nextLeft + 'px', top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -662,19 +598,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = getActiveBlockNextSize({
-        width: nextWidth + 'px',
-        height: nextHeight + 'px',
-      });
-      const nextPosition = getActiveBlockNextPosition({
-        left: nextLeft + 'px',
-        top: nextTop + 'px',
-      });
-
       const nextState = getActiveBlockNextState({
         block: activedBlockGroup,
-        nextSize,
-        nextPosition,
+        nextSize: { width: nextWidth + 'px', height: nextHeight + 'px' },
+        nextPosition: { left: nextLeft + 'px', top: nextTop + 'px' },
       });
 
       if (activedBlockGroup.subType !== 'text') {
@@ -719,14 +646,17 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         onMouseDown={(e) => onMouseDown(e, 'topLeft')}
         onMouseUp={() => onMouseUp(nowUpdate)}
       />
+
       <Updator.TopRightEdge
         onMouseDown={(e) => onMouseDown(e, 'topRight')}
         onMouseUp={() => onMouseUp(nowUpdate)}
       />
+
       <Updator.BottomRightEdge
         onMouseDown={(e) => onMouseDown(e, 'bottomRight')}
         onMouseUp={() => onMouseUp(nowUpdate)}
       />
+
       <Updator.BottomLeftEdge
         onMouseDown={(e) => onMouseDown(e, 'bottomLeft')}
         onMouseUp={() => onMouseUp(nowUpdate)}

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -298,6 +298,25 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     /* eslint-disable-next-line */
   }, [isUpdating]);
 
+  const getNextFromBottom = (y: number) => {
+    if (activedBlockGroup === null || activedBlockGroup.type !== 'block') {
+      return {
+        nextTop: 0,
+        nextBottom: 0,
+      };
+    }
+    const nextTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
+
+    const nextBottom = y + pageState.scrollY - +pageState.top;
+
+    const isReversed = nextBottom < nextTop;
+
+    return {
+      nextTop: isReversed ? nextBottom : nextTop,
+      nextBottom: isReversed ? nextTop : nextBottom,
+    };
+  };
+
   useEffect(() => {
     const lineBottomMouseMoveHandler = (e: MouseEvent) => {
       if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
@@ -305,20 +324,16 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
       const { clientY } = e;
 
-      const activedBlockTop = convertPxStringToNumber(activedBlockGroup.style.position.top);
-
-      const nextHeight = clientY + pageState.scrollY - +pageState.top - activedBlockTop;
-
-      const isReversed = nextHeight < 0;
+      const { nextTop, nextBottom } = getNextFromBottom(clientY);
 
       const nextPosition = {
         ...activedBlockGroup.style.position,
-        top: (isReversed ? activedBlockTop + nextHeight : activedBlockTop) + 'px',
+        top: nextTop + 'px',
       };
 
       const nextSize = {
         ...activedBlockGroup.style.size,
-        height: (isReversed ? -1 : 1) * nextHeight + 'px',
+        height: nextBottom - nextTop + 'px',
       };
 
       if (activedBlockGroup.subType !== 'text') {

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -6,7 +6,16 @@ import { useBlockGroupsAtom, useResizablePageAtom, useTemplateTaskHistories } fr
 
 import { convertPxStringToNumber } from '@utils/index';
 
-import { DefaultBox, Directions, EdgeDirections, NonTextBlock, TextBlock } from 'ui';
+import {
+  Blocks,
+  DefaultBox,
+  Directions,
+  EdgeDirections,
+  GroupBlockSize,
+  NonTextBlock,
+  Position,
+  TextBlock,
+} from 'ui';
 
 import { NodeItemPropsInterface } from './types';
 
@@ -204,8 +213,8 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     if (isMousePressing || isUpdating[direction]) return;
 
     setIsMousePressing(() => true);
-    setNowUpdate(() => direction);
     setIsUpdating((state) => ({ ...state, [direction]: true }));
+    setNowUpdate(() => direction);
   };
 
   const onMouseUp = (direction: EdgeDirections | Directions | null) => {
@@ -220,6 +229,55 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     setIsMousePressing(() => false);
     setIsUpdating((state) => ({ ...state, [direction]: false }));
     setNowUpdate(() => null);
+  };
+
+  const getActiveBlockNextSize = (props: Partial<GroupBlockSize>): GroupBlockSize => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
+      return {
+        width: 'auto',
+        height: 'auto',
+      };
+    }
+
+    return {
+      ...activedBlockGroup.style.size,
+      ...props,
+    };
+  };
+
+  const getActiveBlockNextPosition = (props: Partial<Position>): Position => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') {
+      return {
+        top: 'auto',
+        right: 'auto',
+        bottom: 'auto',
+        left: 'auto',
+      };
+    }
+
+    return {
+      ...activedBlockGroup.style.position,
+      ...props,
+    };
+  };
+
+  const getActiveBlockNextState = ({
+    block,
+    nextSize,
+    nextPosition,
+  }: {
+    block: Blocks;
+    nextSize: GroupBlockSize;
+    nextPosition: Position;
+  }) => {
+    return {
+      ...block,
+      style: {
+        ...block.style,
+        size: nextSize,
+        position: nextPosition,
+      },
+    };
   };
 
   const getNextFromTop = (y: number): { nextTop: number; nextBottom: number } => {
@@ -319,24 +377,14 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const { nextTop, nextBottom } = getNextFromTop(clientY);
       const nextHeight = nextBottom - nextTop;
 
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
-        top: nextTop + 'px',
-      };
+      const nextSize = getActiveBlockNextSize({ height: nextHeight + 'px' });
+      const nextPosition = getActiveBlockNextPosition({ top: nextTop + 'px' });
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
-        height: nextHeight + 'px',
-      };
-
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -363,24 +411,14 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
       const { nextTop, nextBottom } = getNextFromBottom(clientY);
 
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
-        top: nextTop + 'px',
-      };
+      const nextSize = getActiveBlockNextSize({ height: nextBottom - nextTop + 'px' });
+      const nextPosition = getActiveBlockNextPosition({ top: nextTop + 'px' });
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
-        height: nextBottom - nextTop + 'px',
-      };
-
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -409,24 +447,14 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
       const nextWidth = nextRight - nextLeft;
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
-        width: nextWidth + 'px',
-      };
+      const nextSize = getActiveBlockNextSize({ width: nextWidth + 'px' });
+      const nextPosition = getActiveBlockNextPosition({ left: nextLeft + 'px' });
 
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
-        left: nextLeft + 'px',
-      };
-
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -463,24 +491,14 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const { nextLeft, nextRight } = getNextFromRight(clientX);
       const nextWidth = nextRight - nextLeft;
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
-        width: nextWidth + 'px',
-      };
+      const nextSize = getActiveBlockNextSize({ width: nextWidth + 'px' });
+      const nextPosition = getActiveBlockNextPosition({ left: nextLeft + 'px' });
 
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
-        left: nextLeft + 'px',
-      };
-
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -502,7 +520,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return;
     if (!isUpdating.topLeft) return;
 
-    const edgesBottomLeftMouseMoveHandler = (e: MouseEvent) => {
+    const edgesTopLeftMouseMoveHandler = (e: MouseEvent) => {
       const { clientX, clientY } = e;
 
       const { nextTop, nextBottom } = getNextFromTop(clientY);
@@ -511,26 +529,20 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
+      const nextSize = getActiveBlockNextSize({
         width: nextWidth + 'px',
         height: nextHeight + 'px',
-      };
-
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
+      });
+      const nextPosition = getActiveBlockNextPosition({
         left: nextLeft + 'px',
         top: nextTop + 'px',
-      };
+      });
 
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -539,10 +551,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       }
     };
 
-    window.addEventListener('mousemove', edgesBottomLeftMouseMoveHandler, { passive: true });
+    window.addEventListener('mousemove', edgesTopLeftMouseMoveHandler, { passive: true });
 
     return () => {
-      window.removeEventListener('mousemove', edgesBottomLeftMouseMoveHandler);
+      window.removeEventListener('mousemove', edgesTopLeftMouseMoveHandler);
     };
 
     /* eslint-disable-next-line */
@@ -561,22 +573,22 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: {
-            ...activedBlockGroup.style.size,
-            width: nextWidth + 'px',
-            height: nextHeight + 'px',
-          },
-          position: {
-            ...activedBlockGroup.style.position,
-            left: nextLeft + 'px',
-            top: nextTop + 'px',
-          },
-        },
-      };
+      const nextSize = getActiveBlockNextSize({
+        width: nextWidth + 'px',
+        height: nextHeight + 'px',
+      });
+
+      const nextPosition = getActiveBlockNextPosition({
+        left: nextLeft + 'px',
+        top: nextTop + 'px',
+      });
+
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
+
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
       } else {
@@ -606,26 +618,20 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
+      const nextSize = getActiveBlockNextSize({
         width: nextWidth + 'px',
         height: nextHeight + 'px',
-      };
-
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
+      });
+      const nextPosition = getActiveBlockNextPosition({
         left: nextLeft + 'px',
         top: nextTop + 'px',
-      };
+      });
 
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);
@@ -656,26 +662,20 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
-      const nextSize = {
-        ...activedBlockGroup.style.size,
+      const nextSize = getActiveBlockNextSize({
         width: nextWidth + 'px',
         height: nextHeight + 'px',
-      };
-
-      const nextPosition = {
-        ...activedBlockGroup.style.position,
+      });
+      const nextPosition = getActiveBlockNextPosition({
         left: nextLeft + 'px',
         top: nextTop + 'px',
-      };
+      });
 
-      const nextState = {
-        ...activedBlockGroup,
-        style: {
-          ...activedBlockGroup.style,
-          size: nextSize,
-          position: nextPosition,
-        },
-      };
+      const nextState = getActiveBlockNextState({
+        block: activedBlockGroup,
+        nextSize,
+        nextPosition,
+      });
 
       if (activedBlockGroup.subType !== 'text') {
         changeBlockState(nextState as TextBlock);

--- a/apps/web/templates/template-create/block-groups/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/Updator.tsx
@@ -6,7 +6,7 @@ import { useBlockGroupsAtom, useResizablePageAtom, useTemplateTaskHistories } fr
 
 import { convertPxStringToNumber } from '@utils/index';
 
-import { DefaultBox, Directions, EdgeDirections } from 'ui';
+import { DefaultBox, Directions, EdgeDirections, NonTextBlock, TextBlock } from 'ui';
 
 import { NodeItemPropsInterface } from './types';
 
@@ -329,28 +329,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         height: nextHeight + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -382,28 +373,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         height: nextBottom - nextTop + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -437,28 +419,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         left: nextLeft + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -500,28 +473,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         left: nextLeft + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -559,28 +523,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         top: nextTop + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -606,44 +561,26 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
       const nextWidth = nextRight - nextLeft;
       const nextHeight = nextBottom - nextTop;
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: {
+            ...activedBlockGroup.style.size,
+            width: nextWidth + 'px',
+            height: nextHeight + 'px',
+          },
+          position: {
+            ...activedBlockGroup.style.position,
+            left: nextLeft + 'px',
+            top: nextTop + 'px',
+          },
+        },
+      };
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: {
-              ...activedBlockGroup.style.size,
-              width: nextWidth + 'px',
-              height: nextHeight + 'px',
-            },
-            position: {
-              ...activedBlockGroup.style.position,
-              left: nextLeft + 'px',
-              top: nextTop + 'px',
-            },
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: {
-              ...activedBlockGroup.style.size,
-              width: nextWidth + 'px',
-              height: nextHeight + 'px',
-            },
-            position: {
-              ...activedBlockGroup.style.position,
-              left: nextLeft + 'px',
-              top: nextTop + 'px',
-            },
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -681,28 +618,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         top: nextTop + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 
@@ -740,28 +668,19 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
         top: nextTop + 'px',
       };
 
+      const nextState = {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: nextSize,
+          position: nextPosition,
+        },
+      };
+
       if (activedBlockGroup.subType !== 'text') {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as TextBlock);
       } else {
-        const nextState = {
-          ...activedBlockGroup,
-          style: {
-            ...activedBlockGroup.style,
-            size: nextSize,
-            position: nextPosition,
-          },
-        };
-
-        changeBlockState(nextState);
+        changeBlockState(nextState as NonTextBlock);
       }
     };
 

--- a/apps/web/templates/template-create/block-groups/updator/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/updator/Updator.tsx
@@ -10,9 +10,9 @@ import {
   Blocks,
   DefaultBox,
   Directions,
-  DirectionsContstants,
+  DirectionsConstants,
   EdgeDirections,
-  EdgeDirectionsContstants,
+  EdgeDirectionsConstants,
   GroupBlockSize,
   NonTextBlock,
   Position,
@@ -22,101 +22,102 @@ import {
 import { NodeItemPropsInterface } from '../types';
 
 interface LineInterface {
+  direction: DirectionsConstants;
   onMouseDown: (e: ReactMouseEvent) => void;
   onMouseUp: () => void;
 }
 
 interface EdgeInterface {
+  direction: EdgeDirectionsConstants;
   onMouseDown: (e: ReactMouseEvent) => void;
   onMouseUp: () => void;
 }
 
-Updator.Top = function UpdatorTopLine({ onMouseDown, onMouseUp }: LineInterface) {
+function UpdatorLine({ direction, onMouseDown, onMouseUp }: LineInterface) {
   const theme = useTheme();
+
+  const cursors = {
+    [DirectionsConstants.top]: 'ns-resize',
+    [DirectionsConstants.right]: 'ew-resize',
+    [DirectionsConstants.bottom]: 'ns-resize',
+    [DirectionsConstants.left]: 'ew-resize',
+  };
+
+  const tops = {
+    [DirectionsConstants.top]: '-1px',
+    [DirectionsConstants.right]: '0',
+    [DirectionsConstants.bottom]: '100%',
+    [DirectionsConstants.left]: '0',
+  };
+
+  const lefts = {
+    [DirectionsConstants.top]: '0',
+    [DirectionsConstants.right]: '100%',
+    [DirectionsConstants.bottom]: '-1px',
+    [DirectionsConstants.left]: '-1px',
+  };
+
+  const widths = {
+    [DirectionsConstants.top]: '100%',
+    [DirectionsConstants.right]: '2px',
+    [DirectionsConstants.bottom]: '100%',
+    [DirectionsConstants.left]: '2px',
+  };
+
+  const heights = {
+    [DirectionsConstants.top]: '2px',
+    [DirectionsConstants.right]: '100%',
+    [DirectionsConstants.bottom]: '2px',
+    [DirectionsConstants.left]: '100%',
+  };
 
   return (
     <DefaultBox
-      cursor="ns-resize"
+      cursor={cursors[direction]}
       position="absolute"
       zIndex={9999}
-      left="0"
-      top="-1px"
-      width="100%"
-      height="2px"
+      left={lefts[direction]}
+      top={tops[direction]}
+      width={widths[direction]}
+      height={heights[direction]}
       background={theme.color.primary[200]}
       onMouseDownCapture={onMouseDown}
       onMouseUp={onMouseUp}
     />
   );
-};
+}
 
-Updator.Right = function UpdatorRightLine({ onMouseDown, onMouseUp }: LineInterface) {
+function UpdatorEdge({ direction, onMouseDown, onMouseUp }: EdgeInterface) {
   const theme = useTheme();
+
+  const cursors = {
+    [EdgeDirectionsConstants.topLeft]: 'nwse-resize',
+    [EdgeDirectionsConstants.topRight]: 'nesw-resize',
+    [EdgeDirectionsConstants.bottomRight]: 'nwse-resize',
+    [EdgeDirectionsConstants.bottomLeft]: 'nesw-resize',
+  };
+
+  const tops = {
+    [EdgeDirectionsConstants.topLeft]: '-3px',
+    [EdgeDirectionsConstants.topRight]: '-3px',
+    [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
+    [EdgeDirectionsConstants.bottomLeft]: 'calc(100% - 3px)',
+  };
+
+  const lefts = {
+    [EdgeDirectionsConstants.topLeft]: '-3px',
+    [EdgeDirectionsConstants.topRight]: 'calc(100% - 3px)',
+    [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
+    [EdgeDirectionsConstants.bottomLeft]: '-3px',
+  };
 
   return (
     <DefaultBox
-      cursor="ew-resize"
-      position="absolute"
-      zIndex={9999}
-      left="100%"
-      top="0"
-      width="2px"
-      height="100%"
-      background={theme.color.primary[200]}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
-
-Updator.Bottom = function UpdatorLeftLine({ onMouseDown, onMouseUp }: LineInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="ns-resize"
-      position="absolute"
-      zIndex={9999}
-      left="-1px"
-      top="100%"
-      width="100%"
-      height="2px"
-      background={theme.color.primary[200]}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
-
-Updator.Left = function UpdatorBototmLine({ onMouseDown, onMouseUp }: LineInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="ew-resize"
-      position="absolute"
-      zIndex={9999}
-      left="-1px"
-      top="0"
-      width="2px"
-      height="100%"
-      background={theme.color.primary[200]}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
-
-Updator.TopLeftEdge = function UpdatorLeftTopEdge({ onMouseDown, onMouseUp }: EdgeInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="nwse-resize"
+      cursor={cursors[direction]}
       position="absolute"
       zIndex={10000}
-      left="-3px"
-      top="-3px"
+      left={lefts[direction]}
+      top={tops[direction]}
       width="6px"
       height="6px"
       background={theme.color.white}
@@ -125,70 +126,7 @@ Updator.TopLeftEdge = function UpdatorLeftTopEdge({ onMouseDown, onMouseUp }: Ed
       onMouseUp={onMouseUp}
     />
   );
-};
-
-Updator.TopRightEdge = function TopRightEdge({ onMouseDown, onMouseUp }: EdgeInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="nesw-resize"
-      position="absolute"
-      zIndex={10000}
-      left="calc(100% - 3px)"
-      top="-3px"
-      width="6px"
-      height="6px"
-      background={theme.color.white}
-      border={theme.border.primaryLight}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
-
-Updator.BottomRightEdge = function UpdatorBottomRightEdge({
-  onMouseDown,
-  onMouseUp,
-}: EdgeInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="nwse-resize"
-      position="absolute"
-      zIndex={10000}
-      left="calc(100% - 3px)"
-      top="calc(100% - 3px)"
-      width="6px"
-      height="6px"
-      background={theme.color.white}
-      border={theme.border.primaryLight}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
-
-Updator.BottomLeftEdge = function UpdatorBottomLeftEdge({ onMouseDown, onMouseUp }: EdgeInterface) {
-  const theme = useTheme();
-
-  return (
-    <DefaultBox
-      cursor="nesw-resize"
-      position="absolute"
-      zIndex={10000}
-      left="-3px"
-      top="calc(100% - 3px)"
-      width="6px"
-      height="6px"
-      background={theme.color.white}
-      border={theme.border.primaryLight}
-      onMouseDownCapture={onMouseDown}
-      onMouseUp={onMouseUp}
-    />
-  );
-};
+}
 
 export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   const { activedBlockGroup, changeBlockState } = useBlockGroupsAtom();
@@ -197,9 +135,9 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   const { addTask } = useTemplateTaskHistories();
 
   const [isMousePressing, setIsMousePressing] = useState(false);
-  const [nowUpdate, setNowUpdate] = useState<
-    EdgeDirectionsContstants | DirectionsContstants | null
-  >(null);
+  const [nowUpdate, setNowUpdate] = useState<EdgeDirectionsConstants | DirectionsConstants | null>(
+    null
+  );
 
   const [blockSnapshot, setBlockSnapshot] = useState<Blocks | null>(null);
 
@@ -220,7 +158,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
   const onMouseDown = (
     e: ReactMouseEvent,
-    direction: EdgeDirectionsContstants | DirectionsContstants
+    direction: EdgeDirectionsConstants | DirectionsConstants
   ) => {
     e.stopPropagation();
 
@@ -368,16 +306,16 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
    */
   const getNextStateStrategyFactory = (action: { type: Directions }) => {
     switch (action.type) {
-      case DirectionsContstants.top: {
+      case DirectionsConstants.top: {
         return topLineStrategy;
       }
-      case DirectionsContstants.right: {
+      case DirectionsConstants.right: {
         return rightLineStrategy;
       }
-      case DirectionsContstants.bottom: {
+      case DirectionsConstants.bottom: {
         return bottomLineStrategy;
       }
-      case DirectionsContstants.left: {
+      case DirectionsConstants.left: {
         return leftLineStrategy;
       }
 
@@ -442,10 +380,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
   const lineMouseMoveHandler = (e: MouseEvent) => {
     if (activedBlockGroup?.type !== 'block') return;
-    if (!nowUpdate || nowUpdate in EdgeDirectionsContstants || !isUpdating[nowUpdate]) return;
+    if (!nowUpdate || nowUpdate in EdgeDirectionsConstants || !isUpdating[nowUpdate]) return;
 
     const getNextState = getNextStateStrategyFactory({
-      type: nowUpdate as DirectionsContstants,
+      type: nowUpdate as DirectionsConstants,
     });
 
     if (getNextState === null) return;
@@ -507,18 +445,18 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     };
   };
 
-  const getEdgeNextStyleStrategyFactory = (action: { type: EdgeDirectionsContstants }) => {
+  const getEdgeNextStyleStrategyFactory = (action: { type: EdgeDirectionsConstants }) => {
     switch (action.type) {
-      case EdgeDirectionsContstants.topLeft: {
+      case EdgeDirectionsConstants.topLeft: {
         return topLeftEdgeGetNextStyleStrategy;
       }
-      case EdgeDirectionsContstants.topRight: {
+      case EdgeDirectionsConstants.topRight: {
         return topRightEdgeGetNextStyleStrategy;
       }
-      case EdgeDirectionsContstants.bottomRight: {
+      case EdgeDirectionsConstants.bottomRight: {
         return bottomRightEdgeGetNextStyleStrategy;
       }
-      case EdgeDirectionsContstants.bottomLeft: {
+      case EdgeDirectionsConstants.bottomLeft: {
         return bottomLeftEdgeGetNextStyleStrategy;
       }
 
@@ -530,10 +468,10 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
   const edgeMouseMoveHandler = (e: MouseEvent) => {
     if (activedBlockGroup?.type !== 'block') return;
-    if (!nowUpdate || nowUpdate in DirectionsContstants || !isUpdating[nowUpdate]) return;
+    if (!nowUpdate || nowUpdate in DirectionsConstants || !isUpdating[nowUpdate]) return;
 
     const nowStrategy = getEdgeNextStyleStrategyFactory({
-      type: nowUpdate as EdgeDirectionsContstants,
+      type: nowUpdate as EdgeDirectionsConstants,
     });
 
     if (nowStrategy === null) return;
@@ -566,45 +504,33 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
 
   return (
     <>
-      <Updator.Top
-        onMouseDown={(e) => onMouseDown(e, DirectionsContstants.top)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
+      {[
+        DirectionsConstants.top,
+        DirectionsConstants.right,
+        DirectionsConstants.bottom,
+        DirectionsConstants.left,
+      ].map((direction) => (
+        <UpdatorLine
+          key={direction}
+          direction={direction}
+          onMouseDown={(e) => onMouseDown(e, direction)}
+          onMouseUp={() => onMouseUp(nowUpdate)}
+        />
+      ))}
 
-      <Updator.Right
-        onMouseDown={(e) => onMouseDown(e, DirectionsContstants.right)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.Bottom
-        onMouseDown={(e) => onMouseDown(e, DirectionsContstants.bottom)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.Left
-        onMouseDown={(e) => onMouseDown(e, DirectionsContstants.left)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.TopLeftEdge
-        onMouseDown={(e) => onMouseDown(e, EdgeDirectionsContstants.topLeft)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.TopRightEdge
-        onMouseDown={(e) => onMouseDown(e, EdgeDirectionsContstants.topRight)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.BottomRightEdge
-        onMouseDown={(e) => onMouseDown(e, EdgeDirectionsContstants.bottomRight)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
-
-      <Updator.BottomLeftEdge
-        onMouseDown={(e) => onMouseDown(e, EdgeDirectionsContstants.bottomLeft)}
-        onMouseUp={() => onMouseUp(nowUpdate)}
-      />
+      {[
+        EdgeDirectionsConstants.topLeft,
+        EdgeDirectionsConstants.topRight,
+        EdgeDirectionsConstants.bottomRight,
+        EdgeDirectionsConstants.bottomLeft,
+      ].map((direction) => (
+        <UpdatorEdge
+          key={direction}
+          direction={direction}
+          onMouseDown={(e) => onMouseDown(e, direction)}
+          onMouseUp={() => onMouseUp(nowUpdate)}
+        />
+      ))}
     </>
   );
 }

--- a/apps/web/templates/template-create/block-groups/updator/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/updator/Updator.tsx
@@ -81,7 +81,7 @@ function UpdatorLine({ direction, onMouseDown, onMouseUp }: LineInterface) {
       width={widths[direction]}
       height={heights[direction]}
       background={theme.color.primary[200]}
-      onMouseDownCapture={onMouseDown}
+      onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
     />
   );
@@ -122,7 +122,7 @@ function UpdatorEdge({ direction, onMouseDown, onMouseUp }: EdgeInterface) {
       height="6px"
       background={theme.color.white}
       border={theme.border.primaryLight}
-      onMouseDownCapture={onMouseDown}
+      onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
     />
   );
@@ -160,6 +160,12 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     e: ReactMouseEvent,
     direction: EdgeDirectionsConstants | DirectionsConstants
   ) => {
+    /**
+     * @description
+     * Updator의 Line은 Leaf들 위에 존재한다.
+     * 이때, 전파를 막지 않는다면, onMouseDown을 하는 시점에서 이미 Leaf에서의 onMouseDown과, onMouseMove가 동시에 동작하게 된다.
+     * 따라서 전파를 막아줌으로써 더이상 버블링을 하지 않도록 한다.
+     */
     e.stopPropagation();
 
     if (activedBlockGroup?.type === 'group' || isMousePressing || isUpdating[direction]) return;

--- a/apps/web/templates/template-create/block-groups/updator/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/updator/Updator.tsx
@@ -20,66 +20,30 @@ import {
 } from 'ui';
 
 import { NodeItemPropsInterface } from '../types';
-
-interface LineInterface {
-  direction: DirectionsConstants;
-  onMouseDown: (e: ReactMouseEvent) => void;
-  onMouseUp: () => void;
-}
-
-interface EdgeInterface {
-  direction: EdgeDirectionsConstants;
-  onMouseDown: (e: ReactMouseEvent) => void;
-  onMouseUp: () => void;
-}
+import { EdgeInterface, LineInterface } from './types';
+import {
+  edgeCursors,
+  edgeLefts,
+  edgeTops,
+  lineCursors,
+  lineHeights,
+  lineLefts,
+  lineTops,
+  lineWidths,
+} from './utils';
 
 function UpdatorLine({ direction, onMouseDown, onMouseUp }: LineInterface) {
   const theme = useTheme();
 
-  const cursors = {
-    [DirectionsConstants.top]: 'ns-resize',
-    [DirectionsConstants.right]: 'ew-resize',
-    [DirectionsConstants.bottom]: 'ns-resize',
-    [DirectionsConstants.left]: 'ew-resize',
-  };
-
-  const tops = {
-    [DirectionsConstants.top]: '-1px',
-    [DirectionsConstants.right]: '0',
-    [DirectionsConstants.bottom]: '100%',
-    [DirectionsConstants.left]: '0',
-  };
-
-  const lefts = {
-    [DirectionsConstants.top]: '0',
-    [DirectionsConstants.right]: '100%',
-    [DirectionsConstants.bottom]: '-1px',
-    [DirectionsConstants.left]: '-1px',
-  };
-
-  const widths = {
-    [DirectionsConstants.top]: '100%',
-    [DirectionsConstants.right]: '2px',
-    [DirectionsConstants.bottom]: '100%',
-    [DirectionsConstants.left]: '2px',
-  };
-
-  const heights = {
-    [DirectionsConstants.top]: '2px',
-    [DirectionsConstants.right]: '100%',
-    [DirectionsConstants.bottom]: '2px',
-    [DirectionsConstants.left]: '100%',
-  };
-
   return (
     <DefaultBox
-      cursor={cursors[direction]}
+      cursor={lineCursors[direction]}
       position="absolute"
       zIndex={9999}
-      left={lefts[direction]}
-      top={tops[direction]}
-      width={widths[direction]}
-      height={heights[direction]}
+      left={lineLefts[direction]}
+      top={lineTops[direction]}
+      width={lineWidths[direction]}
+      height={lineHeights[direction]}
       background={theme.color.primary[200]}
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
@@ -90,34 +54,13 @@ function UpdatorLine({ direction, onMouseDown, onMouseUp }: LineInterface) {
 function UpdatorEdge({ direction, onMouseDown, onMouseUp }: EdgeInterface) {
   const theme = useTheme();
 
-  const cursors = {
-    [EdgeDirectionsConstants.topLeft]: 'nwse-resize',
-    [EdgeDirectionsConstants.topRight]: 'nesw-resize',
-    [EdgeDirectionsConstants.bottomRight]: 'nwse-resize',
-    [EdgeDirectionsConstants.bottomLeft]: 'nesw-resize',
-  };
-
-  const tops = {
-    [EdgeDirectionsConstants.topLeft]: '-3px',
-    [EdgeDirectionsConstants.topRight]: '-3px',
-    [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
-    [EdgeDirectionsConstants.bottomLeft]: 'calc(100% - 3px)',
-  };
-
-  const lefts = {
-    [EdgeDirectionsConstants.topLeft]: '-3px',
-    [EdgeDirectionsConstants.topRight]: 'calc(100% - 3px)',
-    [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
-    [EdgeDirectionsConstants.bottomLeft]: '-3px',
-  };
-
   return (
     <DefaultBox
-      cursor={cursors[direction]}
+      cursor={edgeCursors[direction]}
       position="absolute"
       zIndex={10000}
-      left={lefts[direction]}
-      top={tops[direction]}
+      left={edgeLefts[direction]}
+      top={edgeTops[direction]}
       width="6px"
       height="6px"
       background={theme.color.white}
@@ -404,6 +347,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   };
 
   useEffect(() => {
+    if (!nowUpdate || !(nowUpdate in DirectionsConstants)) return;
     window.addEventListener('mousemove', lineMouseMoveHandler);
 
     return () => {
@@ -501,6 +445,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
   };
 
   useEffect(() => {
+    if (!nowUpdate || !(nowUpdate in EdgeDirectionsConstants)) return;
     window.addEventListener('mousemove', edgeMouseMoveHandler, { passive: true });
 
     return () => {

--- a/apps/web/templates/template-create/block-groups/updator/index.ts
+++ b/apps/web/templates/template-create/block-groups/updator/index.ts
@@ -1,0 +1,1 @@
+export { Updator } from './Updator';

--- a/apps/web/templates/template-create/block-groups/updator/types.ts
+++ b/apps/web/templates/template-create/block-groups/updator/types.ts
@@ -1,0 +1,15 @@
+import { MouseEvent } from 'react';
+
+import { DirectionsConstants, EdgeDirectionsConstants } from 'ui';
+
+export interface LineInterface {
+  direction: DirectionsConstants;
+  onMouseDown: (e: MouseEvent) => void;
+  onMouseUp: () => void;
+}
+
+export interface EdgeInterface {
+  direction: EdgeDirectionsConstants;
+  onMouseDown: (e: MouseEvent) => void;
+  onMouseUp: () => void;
+}

--- a/apps/web/templates/template-create/block-groups/updator/utils.ts
+++ b/apps/web/templates/template-create/block-groups/updator/utils.ts
@@ -1,0 +1,65 @@
+import { DirectionsConstants, EdgeDirectionsConstants } from 'ui';
+
+/**
+ * INFO: Line
+ */
+
+export const lineCursors = {
+  [DirectionsConstants.top]: 'ns-resize',
+  [DirectionsConstants.right]: 'ew-resize',
+  [DirectionsConstants.bottom]: 'ns-resize',
+  [DirectionsConstants.left]: 'ew-resize',
+} as const;
+
+export const lineTops = {
+  [DirectionsConstants.top]: '-1px',
+  [DirectionsConstants.right]: '0',
+  [DirectionsConstants.bottom]: '100%',
+  [DirectionsConstants.left]: '0',
+} as const;
+
+export const lineLefts = {
+  [DirectionsConstants.top]: '0',
+  [DirectionsConstants.right]: '100%',
+  [DirectionsConstants.bottom]: '-1px',
+  [DirectionsConstants.left]: '-1px',
+} as const;
+
+export const lineWidths = {
+  [DirectionsConstants.top]: '100%',
+  [DirectionsConstants.right]: '2px',
+  [DirectionsConstants.bottom]: '100%',
+  [DirectionsConstants.left]: '2px',
+} as const;
+
+export const lineHeights = {
+  [DirectionsConstants.top]: '2px',
+  [DirectionsConstants.right]: '100%',
+  [DirectionsConstants.bottom]: '2px',
+  [DirectionsConstants.left]: '100%',
+} as const;
+
+/**
+ * INFO: Edge
+ */
+
+export const edgeCursors = {
+  [EdgeDirectionsConstants.topLeft]: 'nwse-resize',
+  [EdgeDirectionsConstants.topRight]: 'nesw-resize',
+  [EdgeDirectionsConstants.bottomRight]: 'nwse-resize',
+  [EdgeDirectionsConstants.bottomLeft]: 'nesw-resize',
+} as const;
+
+export const edgeTops = {
+  [EdgeDirectionsConstants.topLeft]: '-3px',
+  [EdgeDirectionsConstants.topRight]: '-3px',
+  [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
+  [EdgeDirectionsConstants.bottomLeft]: 'calc(100% - 3px)',
+} as const;
+
+export const edgeLefts = {
+  [EdgeDirectionsConstants.topLeft]: '-3px',
+  [EdgeDirectionsConstants.topRight]: 'calc(100% - 3px)',
+  [EdgeDirectionsConstants.bottomRight]: 'calc(100% - 3px)',
+  [EdgeDirectionsConstants.bottomLeft]: '-3px',
+} as const;

--- a/packages/ui/types/models/Blocks.ts
+++ b/packages/ui/types/models/Blocks.ts
@@ -133,14 +133,14 @@ export interface TextBlock extends BlockInterface {
   textContent: string;
 }
 
-export enum DirectionsContstants {
+export enum DirectionsConstants {
   top = 'top',
   right = 'right',
   bottom = 'bottom',
   left = 'left',
 }
 
-export enum EdgeDirectionsContstants {
+export enum EdgeDirectionsConstants {
   topLeft = 'topLeft',
   topRight = 'topRight',
   bottomLeft = 'bottomLeft',


### PR DESCRIPTION
## 💌 설명

2가지의 일을 중점적으로 처리했습니다.

### 1. 이벤트 핸들러 캡쳐링/버블링에서의 의미 없는 이벤트 순서 제어 일반화

현재 `mousedown`, `mouseup`, `mousemove`, `click`, `doubleclick` 등 한 컴포넌트에서 신경 쓸 마우스 이벤트가 이미 5가지나 됩니다.
이때 이벤트 전파 방지나, 이벤트 버블링이 많아질 수록 이벤트에 대한 추적이 매우 어려워집니다.
따라서 의미 없는 이벤트 제어는 모두 기본 순서로 제어하도록 하였습니다.
이를 통해 의미 없이 발생하던 캡쳐링을 2개를 변경하여, 코드의 이벤트 로직을 깔끔하게 다듬었습니다.
또한 이벤트 제어를 실시했다면 그 이유를 주석을 달아놓음으로써, 차후 유지보수성을 더욱 높였습니다.

### 2. 리팩토링

마우스 이벤트들은 복수의 이벤트 생성으로 인해 관리가 복잡했습니다.
이때, 분명 하나로 단일적인 이벤트를 처리할 수 있겠다는 확신이 들었고, 진정 의미 있는 리팩토링을 진행했습니다. 😎

결과적으로 다음과 같은 쾌거를 이루어냈습니다.

1. 약 35%(825줄 -> 543줄, diff: -280)의 코드를 절감하고, 재사용성 높게 `Updator`을 리팩토링했습니다. 모든 함수들이 단일 책임에 수렴하는 깔끔한 목적을 갖고 로직을 처리합니다.
2. 이벤트 핸들러를 최적화하였습니다. 2개의 컴포넌트에서 마우스 이벤트를 등록하는 `useEffect`를 10개에서 3개로 줄임으로써 유지보수성을 높였고, 복수 생성이 되지 않음으로 최적화를 달성해냈습니다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

closes #76 

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
