### PR TITLE
BlockModifier을 통한 작업 동기화를 구현한다

### DIFF
--- a/apps/web/atoms/blockGroupsAtom.ts
+++ b/apps/web/atoms/blockGroupsAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 
-import { BlockMemberType, BlockMembersType, Blocks, Groups, IdType } from 'ui';
+import { BlockGroupOptions, BlockMemberType, BlockMembersType, Blocks, Groups, IdType } from 'ui';
 
 export interface BlockGroupToggleStoreInterface {
   [id: string]: boolean;
@@ -10,7 +10,7 @@ export interface BlockGroupsStore {
   groupsStore: Record<string, Groups>;
   blocksStore: Record<string, Blocks>;
 }
-export interface BlockGroupsAtomInterface extends BlockGroupsStore {
+export interface BlockGroupsAtomInterface extends BlockGroupsStore, BlockGroupOptions {
   activeId: IdType;
   activedBlockGroupDepth: number | null;
   detail: BlockMemberType | null;
@@ -44,6 +44,7 @@ export const getInitialBlockState = () => ({
   },
 
   isMount: false,
+  isRemovableByBackspace: true,
 });
 
 export const blocksStateAtom = atom<BlockGroupsAtomInterface>(getInitialBlockState());

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -9,6 +9,7 @@ export { useBlockGroupsAtom } from './useBlockGroupsAtom';
 export { useBorderMatrix } from './useBorderMatrix';
 export { useBorderModifier } from './useBorderModifier';
 export { useBlockGroupMove } from './useBlockGroupMove';
+export { useBlockBeforeSnapshot } from './useBlockBeforeSnapshot';
 
 export { useTemplateTaskHistories } from './useTemplateTaskHistories';
 

--- a/apps/web/hooks/useBlockBeforeSnapshot.ts
+++ b/apps/web/hooks/useBlockBeforeSnapshot.ts
@@ -1,0 +1,22 @@
+/**
+ * NOTE: 추후 pnpm이 개선되면 이를 삭제한다.
+ */
+import type {} from 'node_modules/@types/react';
+
+import { useState } from 'react';
+
+import { Blocks } from 'ui';
+
+export const useBlockBeforeSnapshot = () => {
+  const [blockBeforeSnapshot, setBlockBeforeSnapshot] = useState<Blocks | null>(null);
+
+  const initializeBlockBeforeSnapshot = () => {
+    setBlockBeforeSnapshot(() => null);
+  };
+
+  return {
+    blockBeforeSnapshot,
+    setBlockBeforeSnapshot,
+    initializeBlockBeforeSnapshot,
+  };
+};

--- a/apps/web/hooks/useBlockGroupMove.ts
+++ b/apps/web/hooks/useBlockGroupMove.ts
@@ -2,7 +2,9 @@
  * NOTE: 추후 pnpm이 모노레포를 원활히 지원한다면 제거한다.
  */
 import type {} from 'node_modules/@types/react';
+import { TaskTypeEnum } from 'types';
 
+import { useCallback } from 'react';
 import { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from 'react';
 
 import { convertPxStringToNumber } from '@utils/index';
@@ -59,41 +61,44 @@ export const useBlockGroupMove = ({ data }: { data: UseLeafParams['data'] }) => 
 
   const boxRef = useRef<HTMLDivElement | null>(null);
 
-  const mouseMoveHandler = (e: MouseEvent) => {
-    if (!isPossibleMove || !mouseState.moveActived) return;
+  const mouseMoveHandler = useCallback(
+    (e: MouseEvent) => {
+      if (!isPossibleMove || !mouseState.moveActived) return;
 
-    /**
-     * @inner
-     * 이 역시 mouseState에서 가져오려 했으나, 생각보다 느리다.
-     * 이벤트 관련된 위치 상태값들은 최대한 이벤트 객체에서 가져오는 것이 오히려 더 수월한 듯하다.
-     * (리액트의 전역에서 관리할 때는 항상 필연적으로 리액트에서의 배치로 인한 시간이 추가로 소요되기 때문이다.)
-     */
-    const { clientX, clientY } = e;
+      /**
+       * @inner
+       * 이 역시 mouseState에서 가져오려 했으나, 생각보다 느리다.
+       * 이벤트 관련된 위치 상태값들은 최대한 이벤트 객체에서 가져오는 것이 오히려 더 수월한 듯하다.
+       * (리액트의 전역에서 관리할 때는 항상 필연적으로 리액트에서의 배치로 인한 시간이 추가로 소요되기 때문이다.)
+       */
+      const { clientX, clientY } = e;
 
-    const nowLeft = clientX - +pageState.left - lastOffset.left;
-    const nowTop = pageState.scrollY - +pageState.top + clientY - lastOffset.top;
+      const nowLeft = clientX - +pageState.left - lastOffset.left;
+      const nowTop = pageState.scrollY - +pageState.top + clientY - lastOffset.top;
 
-    updatedPosition.current.left = nowLeft + 'px';
-    updatedPosition.current.top = nowTop + 'px';
+      updatedPosition.current.left = nowLeft + 'px';
+      updatedPosition.current.top = nowTop + 'px';
 
-    const nextState = {
-      ...data,
-      style: {
-        ...data.style,
-        position: {
-          ...data.style.position,
-          left: nowLeft + 'px',
-          top: nowTop + 'px',
+      const nextState = {
+        ...data,
+        style: {
+          ...data.style,
+          position: {
+            ...data.style.position,
+            left: nowLeft + 'px',
+            top: nowTop + 'px',
+          },
         },
-      },
-    };
+      };
 
-    if (data.subType !== 'text') {
-      changeBlockState(nextState as TextBlock);
-    } else {
-      changeBlockState(nextState as NonTextBlock);
-    }
-  };
+      if (data.subType !== 'text') {
+        changeBlockState(nextState as TextBlock);
+      } else {
+        changeBlockState(nextState as NonTextBlock);
+      }
+    },
+    [data, changeBlockState, isPossibleMove, lastOffset, mouseState, pageState]
+  );
 
   useEffect(() => {
     if (!boxRef.current) return;
@@ -118,7 +123,7 @@ export const useBlockGroupMove = ({ data }: { data: UseLeafParams['data'] }) => 
     if (isPossibleMove) {
       if (data.subType === 'text') {
         addTask({
-          taskType: 'update',
+          taskType: TaskTypeEnum.update,
           before: data,
           after: {
             ...data,
@@ -134,7 +139,7 @@ export const useBlockGroupMove = ({ data }: { data: UseLeafParams['data'] }) => 
         });
       } else {
         addTask({
-          taskType: 'update',
+          taskType: TaskTypeEnum.update,
           before: data,
           after: {
             ...data,

--- a/apps/web/hooks/useBlockGroupMove.ts
+++ b/apps/web/hooks/useBlockGroupMove.ts
@@ -2,10 +2,11 @@
  * NOTE: 추후 pnpm이 모노레포를 원활히 지원한다면 제거한다.
  */
 import type {} from 'node_modules/@types/react';
-import { TaskTypeEnum } from 'types';
 
 import { useCallback } from 'react';
 import { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from 'react';
+
+import { TaskTypeEnum } from '@models/index';
 
 import { convertPxStringToNumber } from '@utils/index';
 

--- a/apps/web/hooks/useBlockGroupsAtom.ts
+++ b/apps/web/hooks/useBlockGroupsAtom.ts
@@ -855,6 +855,13 @@ export const useBlockGroupsAtom = () => {
     }
   };
 
+  const setRemovableByBackspace = (isRemovableByBackspace: boolean) => {
+    setBlockGroupState((state) => ({
+      ...state,
+      isRemovableByBackspace,
+    }));
+  };
+
   return {
     blockGroupState,
     activedBlockGroup,
@@ -915,5 +922,7 @@ export const useBlockGroupsAtom = () => {
     updateGroup,
     deleteBlock,
     deleteGroup,
+
+    setRemovableByBackspace,
   };
 };

--- a/apps/web/hooks/useBorderMatrix.ts
+++ b/apps/web/hooks/useBorderMatrix.ts
@@ -2,9 +2,9 @@ import { useAtom } from 'jotai';
 
 import { blockBorderStateAtom, concurrentlyActivedSections } from '@atoms/index';
 
-import { useBlockGroupsAtom } from '@hooks/index';
-
 import { BorderName, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
+
+import { useBlockGroupsAtom } from './useBlockGroupsAtom';
 
 export const useBorderMatrix = () => {
   const [blockBorderState, setBlockBorderState] = useAtom(blockBorderStateAtom);

--- a/apps/web/hooks/useBorderMatrix.ts
+++ b/apps/web/hooks/useBorderMatrix.ts
@@ -2,7 +2,7 @@ import { useAtom } from 'jotai';
 
 import { blockBorderStateAtom, concurrentlyActivedSections } from '@atoms/index';
 
-import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
+import { useBlockGroupsAtom } from '@hooks/index';
 
 import { BorderName, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
 

--- a/apps/web/hooks/useBorderModifier.ts
+++ b/apps/web/hooks/useBorderModifier.ts
@@ -1,9 +1,14 @@
 import { FormEvent } from 'react';
 
-import { Border, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
+import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
 
-import { useBlockGroupsAtom } from './useBlockGroupsAtom';
-import { useBorderMatrix } from './useBorderMatrix';
+/**
+ * @package
+ * import/no-cycle eslint error을 피하기 위해 사용했다.
+ */
+import { useBorderMatrix } from '@hooks/useBorderMatrix';
+
+import { Border, DirectionsConstants, EdgeDirectionsConstants } from 'ui';
 
 export const useBorderModifier = () => {
   const { blockBorderState } = useBorderMatrix();

--- a/apps/web/pages/template/create/index.tsx
+++ b/apps/web/pages/template/create/index.tsx
@@ -1,3 +1,5 @@
+import { TaskTypeEnum } from 'types';
+
 import React, { MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
@@ -801,7 +803,8 @@ export default function TemplateCreatePage() {
 
   const theme = useTheme();
 
-  const { activedBlockGroup, initializeActiveId, addBlock, deleteBlock } = useBlockGroupsAtom();
+  const { blockGroupState, activedBlockGroup, initializeActiveId, addBlock, deleteBlock } =
+    useBlockGroupsAtom();
   const { pageState, setPageWidth, setPageHeight, setPageScale } = useResizablePageAtom();
   const { addTask } = useTemplateTaskHistories();
 
@@ -877,7 +880,7 @@ export default function TemplateCreatePage() {
     addBlock(nextBlock);
 
     addTask({
-      taskType: 'create',
+      taskType: TaskTypeEnum.create,
       before: null,
       after: nextBlock,
     });
@@ -949,9 +952,9 @@ export default function TemplateCreatePage() {
      */
     const deleteBlockGroupHandler = (e: KeyboardEvent) => {
       if (activedBlockGroup !== null && activedBlockGroup.type === 'block') {
-        if (e.key === 'Backspace') {
+        if (e.key === 'Backspace' && blockGroupState.isRemovableByBackspace) {
           addTask({
-            taskType: 'delete',
+            taskType: TaskTypeEnum.delete,
             before: activedBlockGroup,
             after: null,
           });
@@ -969,7 +972,7 @@ export default function TemplateCreatePage() {
       document.body.removeEventListener('keydown', deleteBlockGroupHandler);
     };
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [activedBlockGroup]);
+  }, [activedBlockGroup, blockGroupState.isRemovableByBackspace]);
 
   return (
     <DefaultBox

--- a/apps/web/pages/template/create/index.tsx
+++ b/apps/web/pages/template/create/index.tsx
@@ -1,5 +1,3 @@
-import { TaskTypeEnum } from 'types';
-
 import React, { MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
@@ -13,6 +11,8 @@ import TemplateCreateLayout from '@layouts/TemplateCreateLayout';
 import { BlockPreviewer, NodeList, ResizablePage } from '@templates/template-create';
 
 import { assembledBlockGroups } from '@atoms/blockGroupsAtom';
+
+import { TaskTypeEnum } from '@models/index';
 
 import {
   useBlockGroupsAtom,

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockFillModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockFillModifier.tsx
@@ -1,12 +1,12 @@
 import { TaskTypeEnum } from 'types';
 
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
+import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 
-import { Blocks, DefaultDivider, DefaultHStack, DefaultVStack, StrongText } from 'ui';
+import { DefaultDivider, DefaultHStack, DefaultVStack, StrongText } from 'ui';
 
 import { TemplatedColorInputWithTitlePresenter } from './TemplatedColorInputWithTitle';
 import { TemplatedInputWithTitlePresenter } from './TemplatedInputWithTitlePresenter';
@@ -19,11 +19,8 @@ export function ActivedBlockFillModifier() {
   const { activedBlockGroup, setFillBgStyle, setBgOpacity, setRemovableByBackspace } =
     useBlockGroupsAtom();
 
-  const [blockBeforeSnapshot, setBlockBeforeSnapshot] = useState<Blocks | null>(null);
-
-  const initializeBlockBeforeSnapshot = () => {
-    setBlockBeforeSnapshot(() => null);
-  };
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
 
   const { addTask } = useTemplateTaskHistories();
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockFillModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockFillModifier.tsx
@@ -1,8 +1,8 @@
-import { TaskTypeEnum } from 'types';
-
 import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
+
+import { TaskTypeEnum } from '@models/index';
 
 import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
@@ -1,8 +1,10 @@
+import { TaskHistoryInterface, TaskTypeEnum } from 'types';
+
 import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
+import { useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 
 import { DEFAULT_NONE } from '@utils/index';
 
@@ -20,6 +22,7 @@ import { TemplatedInputWithTitlePresenter } from './TemplatedInputWithTitlePrese
 /* eslint-disable no-console */
 export function ActivedBlockPositionSizeModifier() {
   const { activedBlockGroup, setPositionStyle, setSizeStyle } = useBlockGroupsAtom();
+  const { addTask } = useTemplateTaskHistories();
 
   const theme = useTheme();
 
@@ -30,8 +33,10 @@ export function ActivedBlockPositionSizeModifier() {
       activedBlockGroup === null ||
       activedBlockGroup.type !== 'block' ||
       activedBlockGroup.id === null
-    )
+    ) {
       return;
+    }
+
     setPositionStyle({
       type: 'block',
       id: activedBlockGroup.id,
@@ -47,8 +52,9 @@ export function ActivedBlockPositionSizeModifier() {
       activedBlockGroup === null ||
       activedBlockGroup.type !== 'block' ||
       activedBlockGroup.id === null
-    )
+    ) {
       return;
+    }
 
     setSizeStyle({
       type: 'block',
@@ -58,6 +64,68 @@ export function ActivedBlockPositionSizeModifier() {
         [key]: (e.target as HTMLInputElement).value,
       },
     });
+  };
+
+  const onBlurPosition = (e: FormEvent, key: keyof Position) => {
+    if (
+      activedBlockGroup === null ||
+      activedBlockGroup.type !== 'block' ||
+      activedBlockGroup.id === null
+    ) {
+      return;
+    }
+
+    const nowTask = {
+      taskType: TaskTypeEnum.update,
+      before: activedBlockGroup,
+      after: {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          position: {
+            ...activedBlockGroup.style.position,
+            [key]: (e.target as HTMLInputElement).value,
+          },
+        },
+      },
+    };
+
+    if (activedBlockGroup.subType !== 'text') {
+      addTask(nowTask as TaskHistoryInterface);
+    } else {
+      addTask(nowTask as TaskHistoryInterface);
+    }
+  };
+
+  const onBlurSize = (e: FormEvent, key: keyof GroupBlockSize) => {
+    if (
+      activedBlockGroup === null ||
+      activedBlockGroup.type !== 'block' ||
+      activedBlockGroup.id === null
+    ) {
+      return;
+    }
+
+    const nowTask = {
+      taskType: TaskTypeEnum.update,
+      before: activedBlockGroup,
+      after: {
+        ...activedBlockGroup,
+        style: {
+          ...activedBlockGroup.style,
+          size: {
+            ...activedBlockGroup.style.size,
+            [key]: (e.target as HTMLInputElement).value,
+          },
+        },
+      },
+    };
+
+    if (activedBlockGroup.subType !== 'text') {
+      addTask(nowTask as TaskHistoryInterface);
+    } else {
+      addTask(nowTask as TaskHistoryInterface);
+    }
   };
 
   return (
@@ -80,6 +148,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.position.top ?? DEFAULT_NONE}
             onChange={(e) => onInputPosition(e, 'top')}
+            onBlur={(e) => onBlurPosition(e, 'top')}
           />
 
           <TemplatedInputWithTitlePresenter
@@ -88,6 +157,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.position.left ?? DEFAULT_NONE}
             onChange={(e) => onInputPosition(e, 'left')}
+            onBlur={(e) => onBlurPosition(e, 'left')}
           />
         </DefaultHStack>
 
@@ -98,6 +168,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.size.width ?? DEFAULT_NONE}
             onChange={(e) => onInputSize(e, 'width')}
+            onBlur={(e) => onBlurSize(e, 'width')}
           />
 
           <TemplatedInputWithTitlePresenter
@@ -106,6 +177,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.size.height ?? DEFAULT_NONE}
             onChange={(e) => onInputSize(e, 'height')}
+            onBlur={(e) => onBlurSize(e, 'height')}
           />
         </DefaultHStack>
       </DefaultVStack>

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
@@ -1,15 +1,14 @@
 import { TaskHistoryInterface, TaskTypeEnum } from 'types';
 
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
+import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 
 import { DEFAULT_NONE } from '@utils/index';
 
 import {
-  Blocks,
   DefaultDivider,
   DefaultHStack,
   DefaultVStack,
@@ -25,11 +24,8 @@ export function ActivedBlockPositionSizeModifier() {
   const { activedBlockGroup, setPositionStyle, setSizeStyle, setRemovableByBackspace } =
     useBlockGroupsAtom();
 
-  const [blockBeforeSnapshot, setBlockBeforeSnapshot] = useState<Blocks | null>(null);
-
-  const initializeBlockBeforeSnapshot = () => {
-    setBlockBeforeSnapshot(() => null);
-  };
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
 
   const { addTask } = useTemplateTaskHistories();
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
@@ -1,8 +1,8 @@
-import { TaskHistoryInterface, TaskTypeEnum } from 'types';
-
 import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
+
+import { TaskHistoryInterface, TaskTypeEnum } from '@models/index';
 
 import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
@@ -1,6 +1,6 @@
 import { TaskHistoryInterface, TaskTypeEnum } from 'types';
 
-import React, { FormEvent } from 'react';
+import React, { FormEvent, useState } from 'react';
 
 import { useTheme } from '@emotion/react';
 
@@ -9,6 +9,7 @@ import { useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 import { DEFAULT_NONE } from '@utils/index';
 
 import {
+  Blocks,
   DefaultDivider,
   DefaultHStack,
   DefaultVStack,
@@ -23,6 +24,13 @@ import { TemplatedInputWithTitlePresenter } from './TemplatedInputWithTitlePrese
 export function ActivedBlockPositionSizeModifier() {
   const { activedBlockGroup, setPositionStyle, setSizeStyle, setRemovableByBackspace } =
     useBlockGroupsAtom();
+
+  const [blockBeforeSnapshot, setBlockBeforeSnapshot] = useState<Blocks | null>(null);
+
+  const initializeBlockBeforeSnapshot = () => {
+    setBlockBeforeSnapshot(() => null);
+  };
+
   const { addTask } = useTemplateTaskHistories();
 
   const theme = useTheme();
@@ -31,6 +39,7 @@ export function ActivedBlockPositionSizeModifier() {
 
   const onFocusInput = () => {
     setRemovableByBackspace(false);
+    setBlockBeforeSnapshot(() => activedBlockGroup);
   };
 
   const onInputPosition = (e: FormEvent, key: keyof Position) => {
@@ -82,7 +91,7 @@ export function ActivedBlockPositionSizeModifier() {
 
     const nowTask = {
       taskType: TaskTypeEnum.update,
-      before: activedBlockGroup,
+      before: blockBeforeSnapshot,
       after: {
         ...activedBlockGroup,
         style: {
@@ -102,6 +111,7 @@ export function ActivedBlockPositionSizeModifier() {
     }
 
     setRemovableByBackspace(true);
+    initializeBlockBeforeSnapshot();
   };
 
   const onBlurSize = (e: FormEvent, key: keyof GroupBlockSize) => {
@@ -115,7 +125,7 @@ export function ActivedBlockPositionSizeModifier() {
 
     const nowTask = {
       taskType: TaskTypeEnum.update,
-      before: activedBlockGroup,
+      before: blockBeforeSnapshot,
       after: {
         ...activedBlockGroup,
         style: {
@@ -133,6 +143,9 @@ export function ActivedBlockPositionSizeModifier() {
     } else {
       addTask(nowTask as TaskHistoryInterface);
     }
+
+    setRemovableByBackspace(true);
+    initializeBlockBeforeSnapshot();
   };
 
   return (

--- a/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedBlockPositionSizeModifier.tsx
@@ -21,12 +21,17 @@ import { TemplatedInputWithTitlePresenter } from './TemplatedInputWithTitlePrese
 
 /* eslint-disable no-console */
 export function ActivedBlockPositionSizeModifier() {
-  const { activedBlockGroup, setPositionStyle, setSizeStyle } = useBlockGroupsAtom();
+  const { activedBlockGroup, setPositionStyle, setSizeStyle, setRemovableByBackspace } =
+    useBlockGroupsAtom();
   const { addTask } = useTemplateTaskHistories();
 
   const theme = useTheme();
 
   if (activedBlockGroup === null || activedBlockGroup.type !== 'block') return <div></div>;
+
+  const onFocusInput = () => {
+    setRemovableByBackspace(false);
+  };
 
   const onInputPosition = (e: FormEvent, key: keyof Position) => {
     if (
@@ -95,6 +100,8 @@ export function ActivedBlockPositionSizeModifier() {
     } else {
       addTask(nowTask as TaskHistoryInterface);
     }
+
+    setRemovableByBackspace(true);
   };
 
   const onBlurSize = (e: FormEvent, key: keyof GroupBlockSize) => {
@@ -148,6 +155,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.position.top ?? DEFAULT_NONE}
             onChange={(e) => onInputPosition(e, 'top')}
+            onFocus={onFocusInput}
             onBlur={(e) => onBlurPosition(e, 'top')}
           />
 
@@ -157,6 +165,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.position.left ?? DEFAULT_NONE}
             onChange={(e) => onInputPosition(e, 'left')}
+            onFocus={onFocusInput}
             onBlur={(e) => onBlurPosition(e, 'left')}
           />
         </DefaultHStack>
@@ -168,6 +177,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.size.width ?? DEFAULT_NONE}
             onChange={(e) => onInputSize(e, 'width')}
+            onFocus={onFocusInput}
             onBlur={(e) => onBlurSize(e, 'width')}
           />
 
@@ -177,6 +187,7 @@ export function ActivedBlockPositionSizeModifier() {
             placeholder="입력"
             value={activedBlockGroup?.style?.size.height ?? DEFAULT_NONE}
             onChange={(e) => onInputSize(e, 'height')}
+            onFocus={onFocusInput}
             onBlur={(e) => onBlurSize(e, 'height')}
           />
         </DefaultHStack>

--- a/apps/web/templates/layouts/sidebar/right/ActivedGroupPositionSizeModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedGroupPositionSizeModifier.tsx
@@ -39,6 +39,7 @@ export function ActivedGroupPositionSizeModifier() {
           </StrongText>
         </DefaultVStack>
 
+        {/* TODO: 추후 group에 대한 사이즈 조절을 구현하고, focus, blur 이벤트 처리를 해야한다. */}
         <DefaultHStack paddingBottom="8px" justifyContent="space-between">
           <TemplatedInputWithTitlePresenter
             direction="horizontal"
@@ -48,6 +49,12 @@ export function ActivedGroupPositionSizeModifier() {
             onChange={() => {
               // eslint-disable-next-line
               console.log(TBD);
+            }}
+            onFocus={() => {
+              return;
+            }}
+            onBlur={() => {
+              return;
             }}
           />
 
@@ -59,6 +66,12 @@ export function ActivedGroupPositionSizeModifier() {
             onChange={() => {
               // eslint-disable-next-line
               console.log(TBD);
+            }}
+            onFocus={() => {
+              return;
+            }}
+            onBlur={() => {
+              return;
             }}
           />
         </DefaultHStack>
@@ -73,6 +86,12 @@ export function ActivedGroupPositionSizeModifier() {
               // eslint-disable-next-line
               console.log(TBD);
             }}
+            onFocus={() => {
+              return;
+            }}
+            onBlur={() => {
+              return;
+            }}
           />
 
           <TemplatedInputWithTitlePresenter
@@ -83,6 +102,12 @@ export function ActivedGroupPositionSizeModifier() {
             onChange={() => {
               // eslint-disable-next-line
               console.log(TBD);
+            }}
+            onFocus={() => {
+              return;
+            }}
+            onBlur={() => {
+              return;
             }}
           />
         </DefaultHStack>

--- a/apps/web/templates/layouts/sidebar/right/ActivedImageModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedImageModifier.tsx
@@ -1,8 +1,8 @@
-import { TaskTypeEnum } from 'types';
-
 import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
+
+import { TaskTypeEnum } from '@models/index';
 
 import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedImageModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedImageModifier.tsx
@@ -1,8 +1,10 @@
+import { TaskTypeEnum } from 'types';
+
 import React, { FormEvent } from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
+import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 
 import {
   DefaultButton,
@@ -19,9 +21,32 @@ export function ActivedImageModifier() {
   const theme = useTheme();
 
   // TODO: updateImageResource, deleteImageResource를 추후 넣어야 한다. (이는 모달에서 제어를 할 것 같다. 업로드와 같이.)
-  const { activedBlockGroup, setImageStyle } = useBlockGroupsAtom();
+  const { activedBlockGroup, setImageStyle, setRemovableByBackspace } = useBlockGroupsAtom();
+
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
+
+  const { addTask } = useTemplateTaskHistories();
 
   if (activedBlockGroup === null || activedBlockGroup.subType !== 'image') return <div></div>;
+
+  const onFocusInput = () => {
+    if (activedBlockGroup === null) return;
+
+    setRemovableByBackspace(false);
+    setBlockBeforeSnapshot(activedBlockGroup);
+  };
+
+  const onBlurInput = () => {
+    addTask({
+      taskType: TaskTypeEnum.update,
+      before: blockBeforeSnapshot,
+      after: activedBlockGroup,
+    });
+
+    initializeBlockBeforeSnapshot();
+    setRemovableByBackspace(true);
+  };
 
   const onChangeImagePosition = (e: FormEvent, position: 'top' | 'left') => {
     setImageStyle({
@@ -96,6 +121,8 @@ export function ActivedImageModifier() {
           inputWidth="42px"
           value={activedBlockGroup.imageStyle.position.top}
           onChange={(e) => onChangeImagePosition(e, 'top')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
 
         <TemplatedInputWithTitlePresenter
@@ -105,6 +132,8 @@ export function ActivedImageModifier() {
           inputWidth="42px"
           value={activedBlockGroup.imageStyle.position.left}
           onChange={(e) => onChangeImagePosition(e, 'left')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
 
         <TemplatedInputWithTitlePresenter
@@ -114,6 +143,8 @@ export function ActivedImageModifier() {
           inputWidth="42px"
           value={activedBlockGroup.imageStyle.opacity}
           onChange={onChangeImageOpacity}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
       </DefaultHStack>
     </DefaultVStack>

--- a/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 
-import { useBlockBeforeSnapshot, useTemplateTaskHistories } from '@hooks/index';
-import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
+import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 
 import { DefaultDivider, DefaultHStack, DefaultVStack, StrongText } from 'ui';
 

--- a/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
@@ -1,7 +1,10 @@
+import { TaskTypeEnum } from 'types';
+
 import React from 'react';
 
 import { useTheme } from '@emotion/react';
 
+import { useBlockBeforeSnapshot, useTemplateTaskHistories } from '@hooks/index';
 import { useBlockGroupsAtom } from '@hooks/useBlockGroupsAtom';
 
 import { DefaultDivider, DefaultHStack, DefaultVStack, StrongText } from 'ui';
@@ -22,8 +25,36 @@ export function ActivedTextModifier() {
     setTextStrokeColor,
     setTextFontFamily,
     setTextFontStyle,
+    setRemovableByBackspace,
   } = useBlockGroupsAtom();
 
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
+
+  const onFocusInput = () => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+
+    setRemovableByBackspace(false);
+    setBlockBeforeSnapshot(activedBlockGroup);
+  };
+
+  const { addTask } = useTemplateTaskHistories();
+
+  const onBlurInput = () => {
+    addTask({
+      taskType: TaskTypeEnum.update,
+      before: blockBeforeSnapshot,
+      after: activedBlockGroup,
+    });
+
+    initializeBlockBeforeSnapshot();
+    setRemovableByBackspace(true);
+  };
+
+  /**
+   * @returns
+   * 사실 의미 없기는 하다. 이를 불러오는 부모 컴포넌트에서, activedBlockGroup이 있어야 나오기 때문이다.
+   */
   if (activedBlockGroup === null || activedBlockGroup.subType !== 'text') return <div></div>;
 
   return (
@@ -47,6 +78,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
 
             <TemplatedInputWithTitlePresenter
@@ -61,6 +94,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
           </DefaultHStack>
 
@@ -77,6 +112,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
 
             <TemplatedInputWithTitlePresenter
@@ -91,6 +128,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
           </DefaultHStack>
 
@@ -107,6 +146,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
 
             <TemplatedInputWithTitlePresenter
@@ -121,6 +162,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
           </DefaultHStack>
 
@@ -137,6 +180,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
 
             <TemplatedInputWithTitlePresenter
@@ -151,6 +196,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
           </DefaultHStack>
 
@@ -168,6 +215,8 @@ export function ActivedTextModifier() {
                   value: (e.target as HTMLInputElement).value,
                 });
               }}
+              onFocus={onFocusInput}
+              onBlur={onBlurInput}
             />
           </DefaultHStack>
         </DefaultVStack>

--- a/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/ActivedTextModifier.tsx
@@ -1,8 +1,8 @@
-import { TaskTypeEnum } from 'types';
-
 import React from 'react';
 
 import { useTheme } from '@emotion/react';
+
+import { TaskTypeEnum } from '@models/index';
 
 import { useBlockBeforeSnapshot, useBlockGroupsAtom, useTemplateTaskHistories } from '@hooks/index';
 

--- a/apps/web/templates/layouts/sidebar/right/TemplatedColorInputWithTitle.tsx
+++ b/apps/web/templates/layouts/sidebar/right/TemplatedColorInputWithTitle.tsx
@@ -16,6 +16,8 @@ interface TemplatedColorInputWithTitlePresenterInterface {
   width?: string;
   value: string;
   onChange: InputWithTitlePropsInterface['input']['onInput'];
+  onFocus?: InputWithTitlePropsInterface['input']['onFocus'];
+  onBlur?: InputWithTitlePropsInterface['input']['onBlur'];
 }
 
 /**
@@ -28,6 +30,8 @@ export function TemplatedColorInputWithTitlePresenter({
   width = '48px',
   value,
   onChange,
+  onFocus,
+  onBlur,
 }: TemplatedColorInputWithTitlePresenterInterface) {
   const theme = useTheme();
 
@@ -43,7 +47,14 @@ export function TemplatedColorInputWithTitlePresenter({
         {title}
       </StrongText>
 
-      <ColorInput width="100%" value={value} size="xs" onChange={onChange} />
+      <ColorInput
+        width="100%"
+        value={value}
+        size="xs"
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
     </StackFactory>
   );
 }

--- a/apps/web/templates/layouts/sidebar/right/TemplatedInputWithTitlePresenter.tsx
+++ b/apps/web/templates/layouts/sidebar/right/TemplatedInputWithTitlePresenter.tsx
@@ -11,6 +11,7 @@ interface TemplatedInputWithTitlePresenterPropsInterface {
   inputWidth?: string;
   value?: string;
   onChange: InputWithTitlePropsInterface['input']['onInput'];
+  onBlur: InputWithTitlePropsInterface['input']['onBlur'];
 }
 
 /**
@@ -25,6 +26,7 @@ export function TemplatedInputWithTitlePresenter({
   placeholder,
   value,
   onChange,
+  onBlur,
 }: TemplatedInputWithTitlePresenterPropsInterface) {
   const theme = useTheme();
 
@@ -60,6 +62,7 @@ export function TemplatedInputWithTitlePresenter({
         size: 'xs',
         placeholder,
         onChange,
+        onBlur,
         value,
         bgColor: theme.color.darkGray,
         borderColor: theme.color.darkGray,

--- a/apps/web/templates/layouts/sidebar/right/TemplatedInputWithTitlePresenter.tsx
+++ b/apps/web/templates/layouts/sidebar/right/TemplatedInputWithTitlePresenter.tsx
@@ -11,6 +11,7 @@ interface TemplatedInputWithTitlePresenterPropsInterface {
   inputWidth?: string;
   value?: string;
   onChange: InputWithTitlePropsInterface['input']['onInput'];
+  onFocus: InputWithTitlePropsInterface['input']['onFocus'];
   onBlur: InputWithTitlePropsInterface['input']['onBlur'];
 }
 
@@ -26,6 +27,7 @@ export function TemplatedInputWithTitlePresenter({
   placeholder,
   value,
   onChange,
+  onFocus,
   onBlur,
 }: TemplatedInputWithTitlePresenterPropsInterface) {
   const theme = useTheme();
@@ -62,6 +64,7 @@ export function TemplatedInputWithTitlePresenter({
         size: 'xs',
         placeholder,
         onChange,
+        onFocus,
         onBlur,
         value,
         bgColor: theme.color.darkGray,

--- a/apps/web/templates/layouts/sidebar/right/border-modifier/SubModifier.tsx
+++ b/apps/web/templates/layouts/sidebar/right/border-modifier/SubModifier.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { useBorderMatrix, useBorderModifier } from '@hooks/index';
+import { TaskTypeEnum } from '@models/index';
+
+import {
+  useBlockBeforeSnapshot,
+  useBlockGroupsAtom,
+  useBorderMatrix,
+  useBorderModifier,
+  useTemplateTaskHistories,
+} from '@hooks/index';
 
 import { DefaultHStack, DefaultVStack, EdgeDirectionsConstants } from 'ui';
 
@@ -23,7 +31,32 @@ export function BorderSubModifierFactory() {
 }
 
 function BorderRadiusInput() {
+  const { activedBlockGroup, setRemovableByBackspace } = useBlockGroupsAtom();
   const { activeSectionBorderRadius, setBorderRadiusMiddleWare } = useBorderModifier();
+
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
+  const { addTask } = useTemplateTaskHistories();
+
+  const onFocusInput = () => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+    setBlockBeforeSnapshot(activedBlockGroup);
+    setRemovableByBackspace(false);
+  };
+
+  const onBlurInput = () => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+
+    addTask({
+      taskType: TaskTypeEnum.update,
+      before: blockBeforeSnapshot,
+      after: activedBlockGroup,
+    });
+
+    setRemovableByBackspace(true);
+    initializeBlockBeforeSnapshot();
+  };
+
   return (
     <DefaultVStack spacing={2} paddingTop="4px">
       <DefaultHStack spacing={2}>
@@ -34,6 +67,8 @@ function BorderRadiusInput() {
           placeholder="입력"
           value={activeSectionBorderRadius()}
           onChange={setBorderRadiusMiddleWare}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
       </DefaultHStack>
     </DefaultVStack>
@@ -45,6 +80,30 @@ export function EdgeModifier() {
 }
 
 export function LineModifier() {
+  const { activedBlockGroup, setRemovableByBackspace } = useBlockGroupsAtom();
+  const { blockBeforeSnapshot, setBlockBeforeSnapshot, initializeBlockBeforeSnapshot } =
+    useBlockBeforeSnapshot();
+  const { addTask } = useTemplateTaskHistories();
+
+  const onFocusInput = () => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+    setBlockBeforeSnapshot(activedBlockGroup);
+    setRemovableByBackspace(false);
+  };
+
+  const onBlurInput = () => {
+    if (activedBlockGroup === null || activedBlockGroup.type === 'group') return;
+
+    addTask({
+      taskType: TaskTypeEnum.update,
+      before: blockBeforeSnapshot,
+      after: activedBlockGroup,
+    });
+
+    setRemovableByBackspace(true);
+    initializeBlockBeforeSnapshot();
+  };
+
   const {
     activeSectionBorderColor,
     activeSectionBorderOpacity,
@@ -63,6 +122,8 @@ export function LineModifier() {
           placeholder="입력"
           value={activeSectionBorderWidth()}
           onChange={(e) => setBorderMiddleware(e, 'width')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
 
         <BorderRadiusInput />
@@ -74,6 +135,8 @@ export function LineModifier() {
           placeholder="입력"
           value={activeSectionBorderStyle()}
           onChange={(e) => setBorderMiddleware(e, 'style')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
       </DefaultHStack>
 
@@ -84,6 +147,8 @@ export function LineModifier() {
           title="색상"
           value={activeSectionBorderColor()}
           onChange={(e) => setBorderMiddleware(e, 'color')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
 
         <TemplatedInputWithTitlePresenter
@@ -93,6 +158,8 @@ export function LineModifier() {
           placeholder="입력"
           value={activeSectionBorderColor()}
           onChange={(e) => setBorderMiddleware(e, 'color')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
 
         <TemplatedInputWithTitlePresenter
@@ -102,6 +169,8 @@ export function LineModifier() {
           placeholder="입력"
           value={activeSectionBorderOpacity()}
           onChange={(e) => setBorderMiddleware(e, 'opacity')}
+          onFocus={onFocusInput}
+          onBlur={onBlurInput}
         />
       </DefaultHStack>
     </DefaultVStack>

--- a/apps/web/templates/template-create/block-groups/updator/Updator.tsx
+++ b/apps/web/templates/template-create/block-groups/updator/Updator.tsx
@@ -2,6 +2,8 @@ import React, { MouseEvent as ReactMouseEvent, useEffect, useState } from 'react
 
 import { useTheme } from '@emotion/react';
 
+import { TaskTypeEnum } from '@models/index';
+
 import { useBlockGroupsAtom, useResizablePageAtom, useTemplateTaskHistories } from '@hooks/index';
 
 import { convertPxStringToNumber } from '@utils/index';
@@ -123,7 +125,7 @@ export function Updator({ item }: { item: NodeItemPropsInterface['item'] }) {
     if (!isMousePressing || !direction || !isUpdating[direction]) return;
 
     addTask({
-      taskType: 'update',
+      taskType: TaskTypeEnum.update,
       before: item,
       after: activedBlockGroup,
     });

--- a/apps/web/types/models/task-histories/index.ts
+++ b/apps/web/types/models/task-histories/index.ts
@@ -18,10 +18,16 @@ export type TasksDBStoreType = IDBPObjectStore<
   TransactionType.readwrite
 >;
 
-export type TaskType = 'create' | 'update' | 'delete';
+export enum TaskTypeEnum {
+  'create' = 'create',
+  'update' = 'update',
+  'delete' = 'delete',
+}
+
+// export type TaskType = 'create' | 'update' | 'delete';
 
 export interface TaskHistoryInterface {
-  taskType: TaskType;
+  taskType: TaskTypeEnum;
   before: BlockMemberType | null;
   after: BlockMemberType | null;
 }

--- a/packages/ui/block-group/types.ts
+++ b/packages/ui/block-group/types.ts
@@ -15,9 +15,19 @@ interface BlockHoverEventParams extends BlockGroupPriorities {
 
 export type BlockHoverEvent = (e: MouseEvent, param: BlockHoverEventParams) => void;
 
+export type BlockGroupOptions = {
+  isRemovableByBackspace: boolean;
+};
+
 export type ClickEventWithType = (
   e: MouseEvent,
-  { type, id, depth, order }: { type: BlockGroupType; id: string } & BlockGroupPriorities
+  {
+    type,
+    id,
+    depth,
+    order,
+    options,
+  }: { type: BlockGroupType; id: string; options: BlockGroupOptions } & BlockGroupPriorities
 ) => void;
 
 export type BlockGroupType = 'block' | 'group';

--- a/packages/ui/block-group/types.ts
+++ b/packages/ui/block-group/types.ts
@@ -27,7 +27,7 @@ export type ClickEventWithType = (
     depth,
     order,
     options,
-  }: { type: BlockGroupType; id: string; options: BlockGroupOptions } & BlockGroupPriorities
+  }: { type: BlockGroupType; id: string; options?: BlockGroupOptions } & BlockGroupPriorities
 ) => void;
 
 export type BlockGroupType = 'block' | 'group';

--- a/packages/ui/input/ColorInput.tsx
+++ b/packages/ui/input/ColorInput.tsx
@@ -13,6 +13,8 @@ export const ColorInput = ({
   width,
   value,
   onChange,
+  onFocus,
+  onBlur,
 }: ColorPropsInterface) => {
   const theme = useTheme();
 
@@ -31,6 +33,8 @@ export const ColorInput = ({
       isInvalid={isInvalid}
       value={value}
       onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 };

--- a/packages/ui/input/Default.tsx
+++ b/packages/ui/input/Default.tsx
@@ -16,6 +16,7 @@ export const DefaultInput = ({
   value,
   onChange,
   onInput,
+  onBlur,
 }: InputPropsInterface) => {
   return (
     <Input
@@ -36,6 +37,7 @@ export const DefaultInput = ({
       value={value}
       onChange={onChange}
       onInput={onInput}
+      onBlur={onBlur}
     />
   );
 };

--- a/packages/ui/input/Default.tsx
+++ b/packages/ui/input/Default.tsx
@@ -16,6 +16,7 @@ export const DefaultInput = ({
   value,
   onChange,
   onInput,
+  onFocus,
   onBlur,
 }: InputPropsInterface) => {
   return (
@@ -37,6 +38,7 @@ export const DefaultInput = ({
       value={value}
       onChange={onChange}
       onInput={onInput}
+      onFocus={onFocus}
       onBlur={onBlur}
     />
   );

--- a/packages/ui/input/types.ts
+++ b/packages/ui/input/types.ts
@@ -15,6 +15,7 @@ export interface InputPropsInterface {
   shape?: 'outline' | 'filled' | 'flushed';
   isInvalid?: boolean;
   onInput?: (e: FormEvent) => void;
+  onFocus?: (e: FormEvent) => void;
   onBlur?: (e: FormEvent) => void;
   onChange?: (e: FormEvent) => void;
   errorMessage?: string | React.ReactNode;

--- a/packages/ui/input/types.ts
+++ b/packages/ui/input/types.ts
@@ -15,6 +15,7 @@ export interface InputPropsInterface {
   shape?: 'outline' | 'filled' | 'flushed';
   isInvalid?: boolean;
   onInput?: (e: FormEvent) => void;
+  onBlur?: (e: FormEvent) => void;
   onChange?: (e: FormEvent) => void;
   errorMessage?: string | React.ReactNode;
   borderColor?: string;


### PR DESCRIPTION
## 💌 설명

Modifier을 핸들링할 때의 작업 동기화를 구현했습니다.
이때, 기존에 발생하는 `keyboard` 이벤트와 `Modifier`에서의 input 이벤트가 conflict 되는 상황이 발생하여 이를 해결했습니다.

## 📎 관련 이슈

closes #77

## 💡 논의해볼 사항

### 전역 상태 관리 추가

앞서 언급했던, conflict되는 상황에 있어, 이를 제어할 수 있도록 `isRemovableByBackspace`라는 프로퍼티 값을 `blockGroupAtom`에 추가했습니다.

이유는 `backspace`로 삭제될 수 있는 시점을 명시하는 것이 전체적으로 앱을 관리하는 데 편하기 때문입니다.

다만 고민이 있던 지점이 있습니다.

> `TemplateCreatePagekeyboardEventAtom`을 따로 구현해서, 전체 앱에서 동작하는 이벤트들을 관리하는 것이 필요하지 않겠는가.

사실 이게 맞을 수도 있습니다.
점점 키보드 이벤트는 많아질 것 같은데요. 이를 핸들링하기 위해서는 별도로 전역상태를 구축하고 만드는 것이 나을 수 있을 거 같습니다.

다만 현재는 MVP를 개발하는 상황에서 이러한 확장성까지 고려하기엔 시간이 빠듯하네요. 😭
(키보드 이벤트를 모두 만들기에는 꽤나 chore한 일이 반복되는 느낌입니다.)
이를 기술부채로 남겨놓아도 충분하다고 판단하여, 이를 보류합니다.

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
